### PR TITLE
Automatic node naming and string representations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,4 +2,5 @@ ignore:
   - "tests"
   - "docs"
   - "setup.py"
+  - "myia/debug"
 comment: false

--- a/myia/anf_ir.py
+++ b/myia/anf_ir.py
@@ -27,22 +27,24 @@ class Debug(types.SimpleNamespace):
 
     Attributes:
         name: The name of the object.
+
     """
-    __curr_id__ = 0
 
-    def __init__(self, **kw):
-        self.name = None
-        super().__init__(**kw)
+    _curr_id = 0
 
-    def force_name(self):
+    def __init__(self, **kwargs):
+        """Construct a Debug object."""
+        self.name: str = None
+        super().__init__(**kwargs)
+
+    @property
+    def debug_name(self):
         """Return the name, create a fresh name if needed."""
         if self.name:
             return self.name
-        Debug.__curr_id__ += 1
-        self.name = f'#{Debug.__curr_id__}'
+        Debug._curr_id += 1
+        self.name = f'#{Debug._curr_id}'
         return self.name
-
-    name: str
 
 
 class Graph:
@@ -67,21 +69,24 @@ class Graph:
         self.debug = GraphDebug()
 
     def __str__(self) -> str:
-        return self.debug.force_name()
+        """Return string representation."""
+        pfx = f'{self.debug.name}=' if self.debug.name else ''
+        return f'{pfx}Graph(parameters={self.parameters})'
 
     def __repr__(self) -> str:
-        pfx = f'{self.debug.name}=' if self.debug.name else ''
-        ret = self.return_ and self.return_.inputs[1]
-        return f'{pfx}Graph(parameters={self.parameters}, return_={ret!r})'
+        """Return representation."""
+        return str(self)
 
     @classmethod
     def __hrepr_resources__(cls, H):
+        """Require the cytoscape plugin for buche."""
         return H.bucheRequire(name='cytoscape',
                               channels='cytoscape',
                               components='cytoscape-graph')
 
     def __hrepr__(self, H, hrepr):
-        from .debug.gprint import GraphPrinter, css
+        """Return HTML representation (uses buche-cytoscape)."""
+        from .debug.gprint import GraphPrinter, css  # type: ignore
         rval = H.cytoscapeGraph(H.style(css))
 
         options = {
@@ -188,9 +193,12 @@ class ANFNode(Node):
         return obj
 
     def __str__(self) -> str:
-        return self.debug.force_name()
+        """Return string representation."""
+        return self.debug.debug_name
 
-    __repr__ = __str__
+    def __repr__(self) -> str:
+        """Return representation."""
+        return str(self)
 
 
 class NodeDebug(Debug):
@@ -327,6 +335,7 @@ class Apply(ANFNode):
         super().__init__(inputs, APPLY, graph)
 
     def __repr__(self) -> str:
+        """Return representation."""
         pfx = f'{self.debug.name}=' if self.debug.name else ''
         return f'{pfx}Apply({[str(x) for x in self.inputs]})'
 
@@ -364,7 +373,12 @@ class Constant(ANFNode):
         super().__init__([], value, None)
 
     def __str__(self) -> str:
-        return str(self.value)
+        """Return string representation."""
+        if self.debug.name:
+            return self.debug.name
+        else:
+            return f'Constant({self.value!r})'
 
     def __repr__(self) -> str:
-        return repr(self.value)
+        """Return representation."""
+        return str(self)

--- a/myia/anf_ir.py
+++ b/myia/anf_ir.py
@@ -16,7 +16,6 @@ from typing import (List, Set, Tuple, Any, Sequence, MutableSequence,
 
 from myia.ir import Node
 from myia.utils import Named
-import json
 
 PARAMETER = Named('PARAMETER')
 APPLY = Named('APPLY')
@@ -76,39 +75,6 @@ class Graph:
     def __repr__(self) -> str:
         """Return representation."""
         return str(self)
-
-    @classmethod
-    def __hrepr_resources__(cls, H):
-        """Require the cytoscape plugin for buche."""
-        return H.bucheRequire(name='cytoscape',
-                              channels='cytoscape',
-                              components='cytoscape-graph')
-
-    def __hrepr__(self, H, hrepr):
-        """Return HTML representation (uses buche-cytoscape)."""
-        from .debug.gprint import GraphPrinter, css  # type: ignore
-        rval = H.cytoscapeGraph(H.style(css))
-
-        options = {
-            'layout': {
-                'name': 'dagre',
-                'rankDir': 'TB'
-            }
-        }
-        rval = rval(H.options(json.dumps(options)))
-        dc = hrepr.config.duplicate_constants
-        fin = hrepr.config.function_in_node
-        fr = hrepr.config.follow_references
-        gpr = GraphPrinter(
-            {self},
-            duplicate_constants=True if dc is None else dc,
-            function_in_node=True if fin is None else fin,
-            follow_references=True if fr is None else fr
-        )
-        gpr.process()
-        for elem in gpr.nodes + gpr.edges:
-            rval = rval(H.element(json.dumps(elem)))
-        return rval
 
 
 class GraphDebug(Debug):

--- a/myia/anf_ir.py
+++ b/myia/anf_ir.py
@@ -67,14 +67,10 @@ class Graph:
         self.return_: Apply = None
         self.debug = GraphDebug()
 
-    def __str__(self) -> str:
-        """Return string representation."""
-        pfx = f'{self.debug.name}=' if self.debug.name else ''
-        return f'{pfx}Graph(parameters={self.parameters})'
-
     def __repr__(self) -> str:
-        """Return representation."""
-        return str(self)
+        """Return string representation."""
+        prefix = f'{self.debug.name} = ' if self.debug.name else ''
+        return f'<{prefix}Graph(parameters={self.parameters})>'
 
 
 class GraphDebug(Debug):
@@ -161,10 +157,6 @@ class ANFNode(Node):
     def __str__(self) -> str:
         """Return string representation."""
         return self.debug.debug_name
-
-    def __repr__(self) -> str:
-        """Return representation."""
-        return str(self)
 
 
 class NodeDebug(Debug):
@@ -302,8 +294,9 @@ class Apply(ANFNode):
 
     def __repr__(self) -> str:
         """Return representation."""
-        pfx = f'{self.debug.name}=' if self.debug.name else ''
-        return f'{pfx}Apply({[str(x) for x in self.inputs]})'
+        prefix = f'{self.debug.name} = ' if self.debug.name else ''
+        return (f'{prefix}{self.__class__.__name__}'
+                f'({self.inputs!r}, {self.graph!r})')
 
 
 class Parameter(ANFNode):
@@ -318,6 +311,11 @@ class Parameter(ANFNode):
     def __init__(self, graph: Graph) -> None:
         """Construct the parameter."""
         super().__init__([], PARAMETER, graph)
+
+    def __repr__(self) -> str:
+        """Return representation."""
+        prefix = f'{self.debug.name} = ' if self.debug.name else ''
+        return f'{prefix}{self.__class__.__name__}({self.graph!r})'
 
 
 class Constant(ANFNode):
@@ -340,11 +338,9 @@ class Constant(ANFNode):
 
     def __str__(self) -> str:
         """Return string representation."""
-        if self.debug.name:
-            return self.debug.name
-        else:
-            return f'Constant({self.value!r})'
+        return str(self.value)
 
     def __repr__(self) -> str:
         """Return representation."""
-        return str(self)
+        prefix = f'{self.debug.name} = ' if self.debug.name else ''
+        return f'{prefix}{self.__class__.__name__}({self.value!r})'

--- a/myia/anf_ir.py
+++ b/myia/anf_ir.py
@@ -296,7 +296,7 @@ class Apply(ANFNode):
 
     def __repr__(self) -> str:
         pfx = f'{self.debug.name}=' if self.debug.name else ''
-        return f'Apply({[str(x) for x in self.inputs]})'
+        return f'{pfx}Apply({[str(x) for x in self.inputs]})'
 
 
 class Parameter(ANFNode):

--- a/myia/debug/gprint.py
+++ b/myia/debug/gprint.py
@@ -1,0 +1,207 @@
+
+from ..anf_ir import ANFNode, Graph, Apply, Parameter, Constant
+import os
+
+
+css_path = f'{os.path.dirname(__file__)}/graph.css'
+css = open(css_path).read()
+
+
+def is_computation(x):
+    return isinstance(x, Apply)
+
+
+def is_constant(x):
+    return isinstance(x, Constant)
+
+
+def is_graph(x):
+    return isinstance(x, Constant) and isinstance(x.value, Graph)
+
+
+class GraphPrinter:
+    def __init__(self,
+                 entry_points,
+                 duplicate_constants=False,
+                 function_in_node=False,
+                 follow_references=False):
+        # Graphs left to process
+        self.graphs = set(entry_points)
+        self.duplicate_constants = duplicate_constants
+        self.function_in_node = function_in_node
+        self.follow_references = follow_references
+        # Nodes processed
+        self.processed = set()
+        # Nodes left to process
+        self.pool = set()
+        # Nodes and edges are accumulated in these lists
+        self.nodes = []
+        self.edges = []
+        # Nodes that are to be colored as return nodes
+        self.returns = set()
+        # IDs for duplicated constants
+        self.currid = 0
+        # Custom rules for nodes that represent certain calls
+        self.custom_rules = {
+            'return': self.process_node_return
+        }
+
+    def id(self, x):
+        return f'X{id(x)}'
+
+    def fresh_id(self):
+        self.currid += 1
+        return f'Y{self.currid}'
+
+    def cynode(self, id, label, classes, parent=None):
+        if not isinstance(id, str):
+            id = self.id(id)
+        data = {'id': id, 'label': str(label)}
+        if parent:
+            parent = parent if isinstance(parent, str) else self.id(parent)
+            data['parent'] = parent
+        self.nodes.append({'data': data, 'classes': classes})
+
+    def cyedge(self, src_id, dest_id, label):
+        if not isinstance(dest_id, str):
+            dest_id = self.id(dest_id)
+        if not isinstance(src_id, str):
+            src_id = self.id(src_id)
+        data = {
+            'id': f'{dest_id}-{src_id}-{label}',
+            'label': label,
+            'source': dest_id,
+            'target': src_id
+        }
+        self.edges.append({'data': data})
+
+    def const_fn(self, node):
+        fn = node.inputs[0] if node.inputs else None
+        if fn and is_constant(fn):
+            if is_graph(fn):
+                return fn.value.debug.force_name()
+            else:
+                return str(fn.value)
+        else:
+            return None
+
+    def add_graph(self, g):
+        if g in self.processed:
+            return
+        name = g.debug.force_name()
+        argnames = [p.debug.force_name() for p in g.parameters]
+        lbl = f'{name}({", ".join(argnames)})'
+        self.cynode(id=g, label=lbl, classes='function')
+        self.processed.add(g)
+
+    def label(self, node):
+        if is_graph(node):
+            lbl = node.value.debug.force_name()
+        elif is_constant(node):
+            lbl = str(node.value)
+        else:
+            lbl = ''
+            if self.function_in_node:
+                cfn = self.const_fn(node)
+                if cfn:
+                    lbl = cfn
+
+            if node.debug.name:
+                if lbl:
+                    lbl += f'→{node.debug.name}'
+                else:
+                    lbl = node.debug.name
+        return lbl or '·'
+
+    def process_node_return(self, node, g, cl):
+        self.cynode(id=node, label='', parent=g, classes='const_output')
+        ret = node.inputs[1]
+        self.process_edges([(node, '', ret)])
+
+    def process_node_generic(self, node, g, cl):
+        lbl = self.label(node)
+
+        self.cynode(id=node, label=lbl, parent=g, classes=cl)
+
+        fn = node.inputs[0] if node.inputs else None
+        if fn and is_graph(fn):
+            self.graphs.add(fn.value)
+
+        edges = []
+        if fn and not (is_constant(fn) and self.function_in_node):
+            edges.append((node, 'F', fn))
+
+        edges += [(node, str(i + 1), inp)
+                  for i, inp in enumerate(node.inputs[1:]) or []]
+
+        self.process_edges(edges)
+
+    def process_node(self, node):
+        if node in self.processed:
+            return
+
+        g = node.graph
+        self.follow(node)
+
+        if node in self.returns:
+            cl = 'output'
+        elif g and node in g.parameters:
+            cl = 'input'
+        elif is_constant(node):
+            cl = 'constant'
+        else:
+            cl = 'intermediate'
+
+        ctfn = self.const_fn(node)
+        if ctfn:
+            if ctfn in self.custom_rules:
+                self.custom_rules[ctfn](node, g, cl)
+            else:
+                self.process_node_generic(node, g, cl)
+        else:
+            self.process_node_generic(node, g, cl)
+
+        self.processed.add(node)
+
+    def process_edges(self, edges):
+        for edge in edges:
+            src, lbl, dest = edge
+            if is_constant(dest) and self.duplicate_constants:
+                self.follow(dest)
+                cid = self.fresh_id()
+                self.cynode(id=cid,
+                            parent=src.graph,
+                            label=self.label(dest),
+                            classes='constant')
+                self.cyedge(src_id=src, dest_id=cid, label=lbl)
+            else:
+                self.pool.add(dest)
+                self.cyedge(src_id=src, dest_id=dest, label=lbl)
+
+    def process_graph(self, g):
+        self.add_graph(g)
+        for inp in g.parameters:
+            self.process_node(inp)
+
+        ret = g.return_.inputs[1]
+        if not is_computation(ret):
+            ret = g.return_
+
+        self.returns.add(ret)
+        self.pool.add(ret)
+
+        while self.pool:
+            node = self.pool.pop()
+            self.process_node(node)
+
+    def process(self):
+        if self.nodes or self.edges:
+            return
+        while self.graphs:
+            g = self.graphs.pop()
+            self.process_graph(g)
+        return self.nodes, self.edges
+
+    def follow(self, node):
+        if is_graph(node) and self.follow_references:
+            self.graphs.add(node.value)

--- a/myia/debug/gprint.py
+++ b/myia/debug/gprint.py
@@ -1,5 +1,5 @@
 
-from ..anf_ir import ANFNode, Graph, Apply, Parameter, Constant
+from ..anf_ir import Graph, Apply, Constant
 import os
 
 
@@ -79,7 +79,7 @@ class GraphPrinter:
         fn = node.inputs[0] if node.inputs else None
         if fn and is_constant(fn):
             if is_graph(fn):
-                return fn.value.debug.force_name()
+                return fn.value.debug.debug_name
             else:
                 return str(fn.value)
         else:
@@ -88,15 +88,15 @@ class GraphPrinter:
     def add_graph(self, g):
         if g in self.processed:
             return
-        name = g.debug.force_name()
-        argnames = [p.debug.force_name() for p in g.parameters]
+        name = g.debug.debug_name
+        argnames = [p.debug.debug_name for p in g.parameters]
         lbl = f'{name}({", ".join(argnames)})'
         self.cynode(id=g, label=lbl, classes='function')
         self.processed.add(g)
 
     def label(self, node):
         if is_graph(node):
-            lbl = node.value.debug.force_name()
+            lbl = node.value.debug.debug_name
         elif is_constant(node):
             lbl = str(node.value)
         else:

--- a/myia/debug/graph.css
+++ b/myia/debug/graph.css
@@ -1,0 +1,54 @@
+node {
+    color: white;
+    background-color: blue;
+    content: data(label);
+    text-valign: center;
+    text-halign: center;
+    shape: rectangle;
+    width: label;
+    padding: 3;
+}
+node.function {
+    padding: 10px;
+    text-valign: top;
+    text-halign: center;
+    color: black;
+    background-color: #ddd;
+}
+edge {
+    target-label: data(label);
+    target-text-offset: 10;
+    color: white;
+    font-size: 12;
+    text-outline-color: #aaa;
+    text-outline-width: 3;
+    curve-style: bezier;
+    source-arrow-shape: triangle;
+    line-color: #aaa;
+    /* source-arrow-shape: circle; */
+}
+/* :selected {
+    background-color: black;
+    line-color: black;
+    target-arrow-color: black;
+    source-arrow-color: black;
+} */
+node.input {
+    background-color: green;
+}
+node.output {
+    background-color: orange;
+}
+node.intermediate {
+    background-color: blue;
+}
+node.constant {
+    background-color: orchid;
+}
+node.const_output {
+    shape: ellipse;
+    width: 10;
+    height: 10;
+    background-color: orange;
+}
+

--- a/tests/test_anf_ir.py
+++ b/tests/test_anf_ir.py
@@ -143,9 +143,10 @@ def test_str_coverage():
     easily.
     """
     g = Graph()
-    ct = Constant(1)
-    ct.debug.name = 'one'
-    objects = [g, Apply([], g), Parameter(g), Constant(0), ct]
+    p = Parameter(g)
+    p.name = 'param'
+    objects = [g, Apply([], g), p, Parameter(g), Constant(0)]
     for o in objects:
         str(o)
         repr(o)
+        o.debug.debug_name

--- a/tests/test_anf_ir.py
+++ b/tests/test_anf_ir.py
@@ -134,3 +134,18 @@ def test_graph():
     return_ = Apply([return_, value], g)
     g.return_ = return_
     g.parameters.append(x)
+
+
+def test_str_coverage():
+    """Just a coverage test for __str__ and __repr__
+
+    Doesn't check that they take particular values since that could change
+    easily.
+    """
+    g = Graph()
+    ct = Constant(1)
+    ct.debug.name = 'one'
+    objects = [g, Apply([], g), Parameter(g), Constant(0), ct]
+    for o in objects:
+        str(o)
+        repr(o)


### PR DESCRIPTION
* Add superclass Debug to GraphDebug and NodeDebug
* `Debug.force_name` names a node if it has no name
* `__str__` returns `node.debug.force_name()`
* `__repr__` returns a shallow representation

The basic idea is that names are lazily generated for nodes if they are needed: if a node has no `debug.name`, calling `str(node)` will generate one. It's a bit unusual for `str` to have a side effect, but it makes sense in this context, since it's only important for a node to have a name if a human is going to read it. `__str__` always just returns the name, whereas `__repr__` is more informative, but still shallow (it calls `str` on the inputs).
