### PR TITLE
Better string representations of nodes and graphs

### DIFF
--- a/myia/utils.py
+++ b/myia/utils.py
@@ -1,4 +1,5 @@
 """General utilities and design patterns."""
+from typing import Any, List
 
 
 class Named:
@@ -21,3 +22,32 @@ class Named:
     def __repr__(self):
         """Return the object's name."""
         return self.name
+
+
+def repr_(obj: Any, **kwargs: Any):
+    """Return unique string representation of object with additional info.
+
+    The usual representation is `<module.Class object at address>`. This
+    function returns `<module.Class(key=value) object at address>` instead, to
+    make objects easier to identify by their attributes.
+
+    Args:
+        **kwargs: The attributes and their values that will be printed as part
+            of the string representation.
+
+    """
+    name = f'{obj.__module__}.{obj.__class__.__name__}'
+    info = ', '.join(f'{key}={value}' for key, value in kwargs.items())
+    address = str(hex(id(obj)))
+    return f'<{name}({info}) object at {address}>'
+
+
+def list_str(lst: List):
+    """Return string representation of a list.
+
+    Unlike the default string representation, this calls `str` instead of
+    `repr` on each element.
+
+    """
+    elements = ', '.join(str(elem) for elem in lst)
+    return f'[{elements}]'

--- a/tests/test_anf_ir.py
+++ b/tests/test_anf_ir.py
@@ -106,7 +106,8 @@ def test_repr_inputs():
     in0 = Constant(0)
     in1 = Constant(1)
     value = Apply([in0, in1], Graph())
-    assert str(value.inputs) == f"Inputs({repr([in0, in1])})"
+    assert repr(value.inputs)
+    assert str(value.inputs)
 
 
 def test_set_inputs_property():
@@ -145,7 +146,7 @@ def test_str_coverage():
     g = Graph()
     p = Parameter(g)
     p.name = 'param'
-    objects = [g, Apply([], g), p, Parameter(g), Constant(0)]
+    objects = [g, Apply([], g), p, Parameter(g), Constant(0), Constant(g)]
     for o in objects:
         str(o)
         repr(o)


### PR DESCRIPTION
Factored this out of #4 so that it is a bit easier to review. This fixes a bunch of issues with the node naming. The current naming:
```pycon
>>> def f(x):
...     return x
>>> parse(f)
<f = Graph(parameters=[x = Parameter(<f = Graph(parameters=[...])>)])>
>>> parse(f).return_
Apply(Inputs([Constant(<myia.primops.Return object at 0x106271630>), x = Parameter(<f = Graph(parameters=[x = Parameter(<f = Graph(parameters=[...])>)])>)]), <f = Graph(parameters=[x = Parameter(<f = Graph(parameters=[...])>)])>)
```
With this PR:
```pycon
>>> parse(f)
<myia.anf_ir.Graph(name=f, parameters=[x], return_=_apply1) object at 0x105c72da0>
>>> parse(f).return_
<myia.anf_ir.Apply(name=_apply2, inputs=[_constant3, x], graph=f) object at 0x105c82eb8>
```
Main changes:
* Make generated names valid variable names
* Base generated names on type of object we are naming
* Use `str` representation where needed to avoid recursively printing the entire graph
* Ensure uniqueness of `repr` by printing object ID like CPython does
* Only represent constant with value if its a literal (to avoid printing really long strings when its value is e.g. a graph)