### PR TITLE
Add output property to Graph

### DIFF
--- a/myia/anf_ir.py
+++ b/myia/anf_ir.py
@@ -97,7 +97,10 @@ class Graph:
     @output.setter
     def output(self, value: 'ANFNode') -> None:
         """Set the graph's output."""
-        self.return_ = Apply([Constant(RETURN), value], self)
+        if self.return_:
+            self.return_.inputs[1] = value
+        else:
+            self.return_ = Apply([Constant(RETURN), value], self)
 
     def __str__(self) -> str:
         """Return readable string representation."""

--- a/myia/anf_ir.py
+++ b/myia/anf_ir.py
@@ -16,11 +16,14 @@ from typing import (List, Set, Tuple, Any, Sequence, MutableSequence,
 
 from myia.ir import Node
 from myia.utils import Named, repr_, list_str
+from .primops import Return
 
 PARAMETER = Named('PARAMETER')
 APPLY = Named('APPLY')
 
 LITERALS = (bool, int, str, float)
+
+RETURN = Return()
 
 
 class Debug(types.SimpleNamespace):
@@ -78,6 +81,23 @@ class Graph:
         self.parameters: List[Parameter] = []
         self.return_: Apply = None
         self.debug = GraphDebug(self)
+
+    @property
+    def output(self) -> 'ANFNode':
+        """
+        Return the graph's output.
+
+        Equal to `self.return_.inputs[1]`, if it exists. Unlike `return_`,
+        `output' may be a constant or belong to a different graph.
+        """
+        if not self.return_ or len(self.return_.inputs) != 2:
+            raise Exception('Graph has no output.')
+        return self.return_.inputs[1]
+
+    @output.setter
+    def output(self, value: 'ANFNode') -> None:
+        """Set the graph's output."""
+        self.return_ = Apply([Constant(RETURN), value], self)
 
     def __str__(self) -> str:
         """Return readable string representation."""

--- a/myia/anf_ir.py
+++ b/myia/anf_ir.py
@@ -16,7 +16,7 @@ from typing import (List, Set, Tuple, Any, Sequence, MutableSequence,
 
 from myia.ir import Node
 from myia.utils import Named, repr_, list_str
-from .primops import Return
+from myia.primops import Return
 
 PARAMETER = Named('PARAMETER')
 APPLY = Named('APPLY')

--- a/tests/test_anf_ir.py
+++ b/tests/test_anf_ir.py
@@ -149,6 +149,11 @@ def test_graph_output():
         isinstance(g.return_.inputs[0], Constant) and \
         g.return_.inputs[0].value is RETURN and \
         g.return_.inputs[1] is one
+    old_return = g.return_
+    two = Constant(2)
+    g.output = two
+    assert g.return_ is old_return
+    assert g.return_.inputs[1] is two
 
 
 def test_str_coverage():

--- a/tests/test_anf_ir.py
+++ b/tests/test_anf_ir.py
@@ -2,7 +2,7 @@ import copy
 
 import pytest
 
-from myia.anf_ir import Graph, Apply, Parameter, Constant, PARAMETER
+from myia.anf_ir import Graph, Apply, Parameter, Constant, PARAMETER, RETURN
 
 
 def test_init_inputs():
@@ -135,6 +135,20 @@ def test_graph():
     return_ = Apply([return_, value], g)
     g.return_ = return_
     g.parameters.append(x)
+
+
+def test_graph_output():
+    g = Graph()
+    with pytest.raises(Exception):
+        print(g.output)
+    one = Constant(1)
+    g.output = one
+    assert g.output is one
+    assert isinstance(g.return_, Apply) and \
+        len(g.return_.inputs) == 2 and \
+        isinstance(g.return_.inputs[0], Constant) and \
+        g.return_.inputs[0].value is RETURN and \
+        g.return_.inputs[1] is one
 
 
 def test_str_coverage():


### PR DESCRIPTION
The purpose of `graph.return_` is so that each graph has at least one node that belongs to it, so that various operations like node replacement are facilitated. This node is always the application of the `Return` primitive, so the real output is in `graph.return_.inputs[1]`. This adds an `output` property that serves as a shortcut to get and set that real output.
