### PR TITLE
DebugInfo framework

### DIFF
--- a/myia/anf_ir.py
+++ b/myia/anf_ir.py
@@ -14,7 +14,7 @@ from typing import (List, Set, Tuple, Any, Sequence, MutableSequence,
 
 from myia.ir import Node
 from myia.utils import Named, repr_, list_str
-from myia.info import AutoNamedDebugInfo
+from myia.info import NamedDebugInfo
 from myia import primops
 
 PARAMETER = Named('PARAMETER')
@@ -42,7 +42,7 @@ class Graph:
         """Construct a graph."""
         self.parameters: List[Parameter] = []
         self.return_: Apply = None
-        self.debug = AutoNamedDebugInfo(type=self.__class__.__name__.lower())
+        self.debug = NamedDebugInfo(type=self.__class__.__name__.lower())
 
     @property
     def output(self) -> 'ANFNode':
@@ -106,7 +106,7 @@ class ANFNode(Node):
         self.value = value
         self.graph = graph
         self.uses: Set[Tuple[ANFNode, int]] = set()
-        self.debug = AutoNamedDebugInfo(type='graph')
+        self.debug = NamedDebugInfo(type=self.__class__.__name__.lower())
 
     @property
     def inputs(self) -> 'Inputs':

--- a/myia/anf_ir.py
+++ b/myia/anf_ir.py
@@ -42,7 +42,7 @@ class Graph:
         """Construct a graph."""
         self.parameters: List[Parameter] = []
         self.return_: Apply = None
-        self.debug = NamedDebugInfo(type=self.__class__.__name__.lower())
+        self.debug = NamedDebugInfo(self)
 
     @property
     def output(self) -> 'ANFNode':
@@ -106,7 +106,7 @@ class ANFNode(Node):
         self.value = value
         self.graph = graph
         self.uses: Set[Tuple[ANFNode, int]] = set()
-        self.debug = NamedDebugInfo(type=self.__class__.__name__.lower())
+        self.debug = NamedDebugInfo(self)
 
     @property
     def inputs(self) -> 'Inputs':

--- a/myia/anf_ir.py
+++ b/myia/anf_ir.py
@@ -9,13 +9,12 @@ implicitly creates a nested function. Functions are first-class objects, so
 returning a nested function creates a closure.
 
 """
-import types
-from ast import AST
 from typing import (List, Set, Tuple, Any, Sequence, MutableSequence,
                     overload, Iterable)
 
 from myia.ir import Node
 from myia.utils import Named, repr_, list_str
+from .info import AutoNamedDebugInfo
 from myia.primops import Return
 
 PARAMETER = Named('PARAMETER')
@@ -24,41 +23,6 @@ APPLY = Named('APPLY')
 LITERALS = (bool, int, str, float)
 
 RETURN = Return()
-
-
-class Debug(types.SimpleNamespace):
-    """Debug information for an object.
-
-    Attributes:
-        name: The name of the object.
-
-    """
-
-    _curr_id = 0
-
-    def __init__(self, obj, **kwargs):
-        """Construct a Debug object."""
-        self.obj: Any = obj
-        self.name: str = None
-        self._id: int = None
-        super().__init__(**kwargs)
-
-    @property
-    def id(self):
-        """Generate a unique, sequential ID number."""
-        if self._id is None:
-            self._id = self._curr_id
-            self.__class__._curr_id += 1
-        return self._id
-
-    @property
-    def debug_name(self):
-        """Return the name, create a fresh name if needed."""
-        if self.name:
-            return self.name
-        prefix = self.obj.__class__.__name__.lower()
-        self.name = f'_{prefix}{self.id}'
-        return self.name
 
 
 class Graph:
@@ -80,7 +44,7 @@ class Graph:
         """Construct a graph."""
         self.parameters: List[Parameter] = []
         self.return_: Apply = None
-        self.debug = GraphDebug(self)
+        self.debug = AutoNamedDebugInfo(type=self.__class__.__name__.lower())
 
     @property
     def output(self) -> 'ANFNode':
@@ -111,21 +75,6 @@ class Graph:
         return repr_(self, name=self.debug.debug_name,
                      parameters=list_str(self.parameters),
                      return_=self.return_)
-
-
-class GraphDebug(Debug):
-    """Debug information for a graph.
-
-    Any information that is used for debugging e.g. plotting, printing, etc.
-    can be stored in this class.
-
-    Attributes:
-        ast: The AST node that created this graph.
-        name: The function name.
-
-    """
-
-    ast: AST
 
 
 class ANFNode(Node):
@@ -159,7 +108,7 @@ class ANFNode(Node):
         self.value = value
         self.graph = graph
         self.uses: Set[Tuple[ANFNode, int]] = set()
-        self.debug = ANFNodeDebug(self)
+        self.debug = AutoNamedDebugInfo(type='graph')
 
     @property
     def inputs(self) -> 'Inputs':
@@ -197,21 +146,6 @@ class ANFNode(Node):
     def __str__(self) -> str:
         """Return readable string representation."""
         return self.debug.debug_name
-
-
-class ANFNodeDebug(Debug):
-    """Debug information for a node.
-
-    Any information that is used for debugging e.g. plotting, printing, etc.
-    can be stored in this class.
-
-    Attributes:
-        ast: The AST node that generated this node.
-        name: The name of this variable.
-
-    """
-
-    ast: AST
 
 
 class Inputs(MutableSequence[ANFNode]):

--- a/myia/debug/gprint.py
+++ b/myia/debug/gprint.py
@@ -361,6 +361,7 @@ class MyiaGraphPrinter(GraphPrinter):
         self.process_edges(edges)
 
     def class_gen(self, node, cl=None):
+        """Generate the class name for this node."""
         g = node.graph
         if cl is not None:
             pass

--- a/myia/debug/gprint.py
+++ b/myia/debug/gprint.py
@@ -2,7 +2,9 @@
 
 from myia.info import DebugInfo
 from myia.anf_ir import Graph, ANFNode, Apply, Constant, Parameter
+from myia.parser import Location
 from myia.primops import Primitive, Return
+from hrepr import hrepr
 import os
 import json
 
@@ -492,3 +494,18 @@ class _Apply:
             return hrepr.hrepr_nowrap(self.inputs[1])['node-return']
         else:
             return super(Apply, self).__hrepr__(H, hrepr)
+
+
+@mixin(Location)
+class _Location:
+    def __hrepr__(self, H, hrepr):
+        return H.div(
+            H.style('.hljs, .hljs-linenos { font-size: 10px !IMPORTANT; }'),
+            H.codeSnippet(
+                src=self.url,
+                language="python",
+                line=self.line,
+                column=self.column + 1,
+                context=hrepr.config.snippet_context or 4
+            )
+        )

--- a/myia/debug/gprint.py
+++ b/myia/debug/gprint.py
@@ -83,8 +83,8 @@ class NodeLabeler:
                 return node.name
             elif node.about:
                 return self.combine_relation(
-                    self.name(node.about),
-                    node.relation
+                    self.name(node.about.debug),
+                    node.about.relation
                 )
             elif force:
                 return f'#{node.id}'

--- a/myia/info.py
+++ b/myia/info.py
@@ -1,0 +1,103 @@
+"""Objects and routines to track debug information."""
+
+from typing import Any
+import types
+import threading
+import traceback
+
+
+# We use per-thread storage for the about stack.
+_about = threading.local()
+_about.stack = [None]
+
+
+def current_info():
+    """Return the `DebugInfo` for the current context."""
+    return _about.stack[-1]
+
+
+class DebugInfo(types.SimpleNamespace):
+    """Debug information for an object.
+
+    Attributes:
+        about: DebugInfo of a different object, that this
+            object is derived from in some way
+        relation: How the object relates to `about`
+        save_trace: Whether the trace of the DebugInfo's
+            creation should be saved.
+        trace: The trace at the moment of the DebugInfo's
+            creation, or None.
+
+    """
+
+    def __init__(self, **kwargs):
+        """Construct a DebugInfo object."""
+        self.about = None
+        self.relation = None
+        self.save_trace: bool = False
+        self.trace: Any = None
+        top = current_info()
+        if top:
+            # Only need to look at the top of the stack
+            self.__dict__.update(top.__dict__)
+
+        self._id: int = None
+        self.__dict__.update(kwargs)
+
+        if self.save_trace:
+            # We remove the last entry that corresponds to
+            # this line in the code.
+            self.trace = traceback.extract_stack()[:-1]
+
+    def __enter__(self):
+        """Set this `DebugInfo` as a template in this context.
+
+        Any `DebugInfo` created within the context of
+        `with self: ...` will inherit all attributes of `self`.
+        """
+        _about.stack.append(self)
+
+    def __exit__(self, type, value, tb):
+        """Exit the context of this `DebugInfo`."""
+        assert _about.stack[-1] is self
+        _about.stack.pop()
+
+
+class AutoNamedDebugInfo(DebugInfo):
+    """Debug information for an object.
+
+    Attributes:
+        type: The type name of the object.
+        name: The name of the object.
+
+    """
+
+    _curr_id = 0
+
+    def __init__(self, **kwargs):
+        """Construct an AutoNamedDebugInfo object."""
+        self.name: str = None
+        self.type: str = None
+        super().__init__(**kwargs)
+
+    @property
+    def id(self):
+        """Generate a unique, sequential ID number."""
+        if self._id is None:
+            self._id = self._curr_id
+            AutoNamedDebugInfo._curr_id += 1
+        return self._id
+
+    @property
+    def debug_name(self):
+        """Return the name, create a fresh name if needed."""
+        if self.name:
+            return self.name
+        prefix = self.type or ''
+        self.name = f'_{prefix}{self.id}'
+        return self.name
+
+
+def about(obj, relation=None):
+    """Set context as being about the given object."""
+    return DebugInfo(about=obj, relation=relation)

--- a/myia/info.py
+++ b/myia/info.py
@@ -23,11 +23,11 @@ class DebugInfo(types.SimpleNamespace):
     If used with the `with` statement, any `DebugInfo` created
     while inside the `with` body will inherit all attributes:
 
-        with DebugInfo(a=1, b=2):
-            info = DebugInfo(c=3)
-            assert info.a == 1
-            assert info.b == 2
-            assert info.c == 3
+    >>> with DebugInfo(a=1, b=2):
+    ...     info = DebugInfo(c=3)
+    ...     assert info.a == 1
+    ...     assert info.b == 2
+    ...     assert info.c == 3
 
     Attributes:
         about: DebugInfo of a different object, that this
@@ -121,10 +121,10 @@ def about(obj, relation=None):
     `DebugInfo(about=obj, relation=rel)` and can be used as
     a context manager:
 
-        with about(x, 'purpose'):
-            info = DebugInfo(a=3)
-            assert info.about is x
-            assert info.relation == 'purpose'
-            assert info.a == 3
+    >>> with about(x, 'purpose'):
+    ...     info = DebugInfo(a=3)
+    ...     assert info.about is x
+    ...     assert info.relation == 'purpose'
+    ...     assert info.a == 3
     """
     return DebugInfo(about=obj, relation=relation)

--- a/myia/parser.py
+++ b/myia/parser.py
@@ -147,7 +147,7 @@ class Parser:
         self.environment = environment
         self.function = function
         _, self.line_offset = inspect.getsourcelines(function)
-        self.url: str = inspect.getfile(function)
+        self.filename: str = inspect.getfile(function)
         self.block_map: Dict[Block, Constant] = {}
         if globals_ is None:
             free_vars = inspect.getclosurevars(function)  # type: ignore
@@ -160,7 +160,7 @@ class Parser:
     def make_location(self, node: ast.AST) -> Location:
         """Create a Location from an AST node."""
         if hasattr(node, 'lineno') and hasattr(node, 'col_offset'):
-            return Location(self.url,
+            return Location(self.filename,
                             node.lineno + self.line_offset - 1,  # type: ignore
                             node.col_offset)  # type: ignore
         else:

--- a/myia/parser.py
+++ b/myia/parser.py
@@ -64,7 +64,7 @@ class Location:
         self.line = line
         self.column = column
 
-    def __str__(self):
+    def __str__(self):  # pragma: no cover
         """Represent a Location."""
         return f'File "{self.url}", line {self.line}, column {self.column}"'
 
@@ -169,7 +169,7 @@ class Parser:
                             node.lineno + self.line_offset - 1,  # type: ignore
                             node.col_offset)  # type: ignore
         else:
-            return None
+            return None  # pragma: no cover
 
     def parse(self) -> Graph:
         """Parse the function into a Myia graph."""

--- a/myia/parser.py
+++ b/myia/parser.py
@@ -42,31 +42,17 @@ import ast
 import inspect
 import textwrap
 from types import FunctionType
-from typing import overload, Any, Dict, List, Optional, Tuple, Type
+from typing import \
+    overload, Any, Dict, List, Optional, Tuple, Type, NamedTuple
 
 from myia.anf_ir import ANFNode, Parameter, Apply, Graph, Constant
 from .info import DebugInfo, about
 
 
-class Location:
-    """A location in source code.
-
-    Attributes:
-        url: The filename.
-        line: The line number.
-        column: The column number.
-
-    """
-
-    def __init__(self, url, line, column):
-        """Initialize a Location."""
-        self.url = url
-        self.line = line
-        self.column = column
-
-    def __str__(self):  # pragma: no cover
-        """Represent a Location."""
-        return f'File "{self.url}", line {self.line}, column {self.column}"'
+class Location(NamedTuple):
+    filename: str
+    line: str
+    column: int
 
 
 class Environment:
@@ -169,7 +155,7 @@ class Parser:
                             node.lineno + self.line_offset - 1,  # type: ignore
                             node.col_offset)  # type: ignore
         else:
-            return None  # pragma: no cover
+            raise TypeError(f'No location for {node}')  # pragma: no cover
 
     def parse(self) -> Graph:
         """Parse the function into a Myia graph."""

--- a/myia/parser.py
+++ b/myia/parser.py
@@ -50,6 +50,15 @@ from .info import DebugInfo, about
 
 
 class Location(NamedTuple):
+    """A location in source code.
+
+    Attributes:
+        filename: The filename.
+        line: The line number.
+        column: The column number.
+
+    """
+
     filename: str
     line: str
     column: int

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,0 +1,25 @@
+
+from myia.info import DebugInfo
+
+
+def test_nested_info():
+    with DebugInfo(a=1):
+        with DebugInfo(b=2):
+            with DebugInfo(c=3):
+                info = DebugInfo(d=4)
+                assert info.a == 1
+                assert info.b == 2
+                assert info.c == 3
+                assert info.d == 4
+    info = DebugInfo(d=4)
+    for attr in 'abc':
+        assert not hasattr(info, attr)
+    assert info.d == 4
+
+
+def test_info_trace():
+    d = DebugInfo()
+    assert d.trace is None
+    with DebugInfo(save_trace=True):
+        d = DebugInfo()
+        assert d.trace is not None

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,13 +1,13 @@
 
 import pytest
-from myia.info import DebugInfo
+from myia.info import DebugInfo, DebugInherit, NamedDebugInfo
 
 
 def test_nested_info():
-    """Test DebugInfo as context manager."""
-    with DebugInfo(a=1):
-        with DebugInfo(b=2):
-            with DebugInfo(c=3):
+    """Test DebugInherit as context manager."""
+    with DebugInherit(a=1):
+        with DebugInherit(b=2):
+            with DebugInherit(c=3):
                 info = DebugInfo(d=4)
                 assert info.a == 1
                 assert info.b == 2
@@ -20,19 +20,19 @@ def test_nested_info():
 
 
 def test_info_trace():
-    """Test that DebugInfo saves a trace."""
-    d = DebugInfo()
+    """Test that NamedDebugInfo saves a trace."""
+    d = NamedDebugInfo()
     assert d.trace is None
-    with DebugInfo(save_trace=True):
-        d = DebugInfo()
+    with DebugInherit(save_trace=True):
+        d = NamedDebugInfo()
         assert d.trace is not None
 
 
 def test_info_obj():
-    """Test that DebugInfo only holds a weak reference to its object."""
+    """Test that NamedDebugInfo only holds a weak reference to its object."""
     class O: pass
     o = O()
-    d = DebugInfo(o)
+    d = NamedDebugInfo(o)
     assert d.obj is o
     del o
     assert d.obj is None

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,8 +1,10 @@
 
+import pytest
 from myia.info import DebugInfo
 
 
 def test_nested_info():
+    """Test DebugInfo as context manager."""
     with DebugInfo(a=1):
         with DebugInfo(b=2):
             with DebugInfo(c=3):
@@ -18,8 +20,19 @@ def test_nested_info():
 
 
 def test_info_trace():
+    """Test that DebugInfo saves a trace."""
     d = DebugInfo()
     assert d.trace is None
     with DebugInfo(save_trace=True):
         d = DebugInfo()
         assert d.trace is not None
+
+
+def test_info_obj():
+    """Test that DebugInfo only holds a weak reference to its object."""
+    class O: pass
+    o = O()
+    d = DebugInfo(o)
+    assert d.obj is o
+    del o
+    assert d.obj is None


### PR DESCRIPTION
This reorganizes the `Debug` objects in `anf_ir` in a new file, `myia.info`, and the `DebugInfo` and `AutoNamedDebugInfo` classes. `DebugInfo` is a context manager and behaves essentially like this:

```python
with DebugInfo(a=1):
    with DebugInfo(b=2):
        info = DebugInfo(c=3)
assert info.a == 1
assert info.b == 2
assert info.c == 3
```

The idea is that a block of code can be executed in a context where certain properties are set, and every node or graph created within that code will inherit these properties. This lets us keep some information without having to pass it around or setting it explicitly. It can also be used as a kind of dynamically scoped store, I suppose.

`DebugInfo` defines the optional attributes `about: DebugInfo` and `relation: str`. For example, the graph for the true branch of the first `if` in function `f` will have `about = f.graph` and `relation = 'if_true'`. This can be used to derive a more informative name for this graph, like `f.if_true`, `✓f`, or something else. I modified `Parser` to set these fields.

It also saves the trace of the creation of the object in `trace` if `save_trace == True`. That was useful to me in the past, so I just threw it in there.
