### PR TITLE
Ignore error D105 in pydocstyle

### DIFF
--- a/.pydocstyle
+++ b/.pydocstyle
@@ -1,2 +1,3 @@
 [pydocstyle]
 ignore-decorators = overload
+add-ignore = D105

--- a/myia/anf_ir.py
+++ b/myia/anf_ir.py
@@ -101,11 +101,9 @@ class Graph:
             self.return_ = Apply([Constant(primops.return_), value], self)
 
     def __str__(self) -> str:
-        """Return readable string representation."""
         return self.debug.debug_name
 
     def __repr__(self) -> str:
-        """Return unique string representation."""
         return repr_(self, name=self.debug.debug_name,
                      parameters=list_str(self.parameters),
                      return_=self.return_)
@@ -193,7 +191,6 @@ class ANFNode(Node):
         return obj
 
     def __str__(self) -> str:
-        """Return readable string representation."""
         return self.debug.debug_name
 
 
@@ -302,11 +299,9 @@ class Inputs(MutableSequence[ANFNode]):
         self.data.insert(index, value)
 
     def __str__(self) -> str:
-        """Return readable string representation."""
         return list_str(self.data)
 
     def __repr__(self) -> str:
-        """Return unique string representation."""
         return f"Inputs({self.node}, {list_str(self.data)})"
 
     def __eq__(self, other) -> bool:
@@ -335,7 +330,6 @@ class Apply(ANFNode):
         super().__init__(inputs, APPLY, graph)
 
     def __repr__(self) -> str:
-        """Return unique string representation."""
         return repr_(self, name=self.debug.debug_name, inputs=self.inputs,
                      graph=self.graph)
 
@@ -354,7 +348,6 @@ class Parameter(ANFNode):
         super().__init__([], PARAMETER, graph)
 
     def __repr__(self) -> str:
-        """Return unique string representation."""
         return repr_(self, name=self.debug.debug_name, graph=self.graph)
 
 
@@ -377,11 +370,9 @@ class Constant(ANFNode):
         super().__init__([], value, None)
 
     def __str__(self) -> str:
-        """Return readable string representation."""
         if isinstance(self.value, LITERALS):
             return str(self.value)
         return super().__str__()
 
     def __repr__(self) -> str:
-        """Return unique string representation."""
         return repr_(self, name=self.debug.debug_name, value=self.value)


### PR DESCRIPTION
After discussing with @abergeron, we would like to move to ignore `D105: Missing docstring in magic method` for pydocstyle. The rationale is that it is pointless and annoying to have to document `__str__`, `__repr__`, `__eq__` and `__hash__`, which all have tightly standardized meaning. This does not affect the requirement to document `__init__`, because that's `D107`.
