### PR TITLE
Improvements to the API when passing functions and closures.

### DIFF
--- a/myia/api.py
+++ b/myia/api.py
@@ -2,7 +2,7 @@
 import ast
 import operator
 from types import FunctionType
-from typing import Any, Dict, List, Type
+from typing import Any, Callable, Dict, List, Type
 
 from myia import parser
 from myia.anf_ir import Graph, Constant, ANFNode
@@ -71,3 +71,9 @@ def parse(func: FunctionType) -> Graph:
 def run(g: Graph, args: List[Any]) -> Any:
     """Evaluate a graph on a set of arguments."""
     return VM.evaluate(g, args)
+
+
+def compile(func: FunctionType) -> Callable:
+    """Return a version of the function that runs using Myia's VM."""
+    g = parse(func)
+    return VM.make_callable(g)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,85 @@
+
+from myia.api import compile
+from myia.py_implementations import getitem, make_tuple as tup
+
+
+def test_function_arg():
+    """Give a Python function as an argument."""
+    def square(x):
+        return x * x
+
+    @compile
+    def f(fn, x, y):
+        return fn(x + y)
+
+    assert f(square, 10, 5) == 225
+
+
+def test_function_in_tuple():
+    """Give a tuple of functions as an argument."""
+    def square(x):
+        return x * x
+
+    def double(x):
+        return x + x
+
+    @compile
+    def f(fns, x, y):
+        f0 = getitem(fns, 0)
+        f1 = getitem(fns, 1)
+        return f1(f0(x + y))
+
+    assert f((square, double), 10, 5) == 450
+    assert f((double, square), 10, 5) == 900
+
+
+def test_return_closure():
+    """Return a closure."""
+    @compile
+    def f(x, y):
+        def g():
+            return x + y
+        return g
+
+    assert f(4, 5)() == 9
+
+
+def test_return_closure_tuple():
+    """Return a tuple of closures."""
+    @compile
+    def f(x, y):
+        def g():
+            return x + y
+        def h():
+            return x * y
+        return tup(g, h)
+
+    g, h = f(4, 5)
+    assert g() == 9
+    assert h() == 20
+
+
+def test_refeed():
+    """Return a closure, then use the closure as an argument."""
+    @compile
+    def f(fn, x, y):
+        def g():
+            return x + y
+        if x == 0:
+            return g
+        else:
+            return fn()
+
+    g = f(None, 0, 6)
+    assert g() == 6
+    assert f(g, 10, 20) == 6
+
+
+def test_return_primitive():
+    """Return a primitive."""
+    @compile
+    def f():
+        return getitem
+
+    g = f()
+    assert g((1, 2, 3), 0) == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,33 @@
-from myia.utils import Named
+import pytest
+
+from myia.utils import Named, smap
 
 
 def test_named():
     named = Named('foo')
     assert repr(named) == 'foo'
+
+
+def _sum(*args):
+    return sum(args)
+
+
+def test_smap():
+    assert smap(_sum, 10, 20) == 30
+    assert smap(_sum, 10, 20, 30, 40) == 100
+    assert smap(_sum, (1, 2, 3), (4, 5, 6)) == (5, 7, 9)
+    assert smap(_sum, [1, 2, 3], [4, 5, 6]) == [5, 7, 9]
+    assert smap(_sum, [(1, [2]), 3], [(4, [5]), 6]) == [(5, [7]), 9]
+
+
+def test_smap_failures():
+    pairs = [
+        ((1, 2), [1, 2]),
+        ((1, 2), (1, 2, 3)),
+        ((1, 2, 3), (1, 2)),
+        (1, [1]),
+        ([[1]], [1]),
+    ]
+    for a, b in pairs:
+        with pytest.raises(TypeError):
+            smap(_sum, a, b)


### PR DESCRIPTION
* `compile` function added to api
* Automatically parse functions passed in arguments
* Closures and primitives returned by `VM` are now callable
* `utils.StructuralMap` added to deal with recursive conversions
* Addresses #31 

This feature will be useful to test the output of the Grad transform, since it returns a closure in a tuple. `compile` is also a nicer api than what we have so far (it can be used as a decorator).