### PR TITLE
Graph utils

### DIFF
--- a/myia/anf_ir_utils.py
+++ b/myia/anf_ir_utils.py
@@ -1,19 +1,48 @@
 """Utilities for manipulating and inspecting the IR."""
+
 from typing import Iterable
 
-from myia.anf_ir import Graph, ANFNode
+from myia.anf_ir import ANFNode, Constant, Graph
+from myia.graph_utils import dfs as _dfs
+
+
+#######################
+# Successor functions #
+#######################
+
+
+def succ_deep(node):
+    """Follow node.incoming and graph references.
+
+    A node's successors are its `incoming` set, or the return node of a graph
+    when a graph Constant is encountered.
+    """
+    if is_constant_graph(node):
+        return [node.value.return_]
+    else:
+        return node.incoming
+
+
+def succ_incoming(node):
+    """Follow node.incoming."""
+    return node.incoming
+
+
+#####################
+# Search algorithms #
+#####################
 
 
 def dfs(root: ANFNode, follow_graph: bool = False) -> Iterable[ANFNode]:
     """Perform a depth-first search."""
-    seen = set()
-    to_visit = [root]
-    while to_visit:
-        node = to_visit.pop()
-        seen.add(node)
-        yield node
-        for in_ in node.incoming:
-            if in_ not in seen:
-                to_visit.append(in_)
-        if isinstance(node.value, Graph) and follow_graph:
-            to_visit.append(node.value.return_)
+    return _dfs(root, succ_deep if follow_graph else succ_incoming)
+
+
+##################
+# Misc utilities #
+##################
+
+
+def is_constant_graph(x: ANFNode) -> bool:
+    """Return whether x is a Constant with a Graph value."""
+    return isinstance(x, Constant) and isinstance(x.value, Graph)

--- a/myia/graph_utils.py
+++ b/myia/graph_utils.py
@@ -1,0 +1,29 @@
+"""Generic graph utilities.
+
+The utilities in this file should be abstract with respect to node types or
+the notion of successor.
+"""
+
+
+from typing import Callable, Iterable, Set, TypeVar
+
+
+T = TypeVar('T')
+
+
+def dfs(root: T, succ: Callable[[T], Iterable[T]]) -> Iterable[T]:
+    """Perform a depth-first search.
+
+    Arguments:
+        root: The node to start from.
+        succ: A function that returns a node's successors.
+    """
+    seen: Set[T] = set()
+    to_visit = [root]
+    while to_visit:
+        node = to_visit.pop()
+        if node in seen:
+            continue
+        seen.add(node)
+        yield node
+        to_visit += succ(node)

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -1,0 +1,29 @@
+"""Test generic graph utilities."""
+
+from myia.graph_utils import dfs
+
+
+def _succ(x):
+    return reversed(x) if isinstance(x, tuple) else ()
+
+
+def test_dfs():
+    a = (1, 2)
+    b = (3, 4, 5)
+    c = (b, 6)
+    d = (a, c)
+
+    order = list(dfs(d, _succ))
+
+    assert order == [d, a, 1, 2, c, b, 3, 4, 5, 6]
+
+
+def test_dfs_dups():
+    a = (1, 2, 2)
+    b = (3, 4, 5, 2)
+    c = (b, 6)
+    d = (a, a, c)
+
+    order = list(dfs(d, _succ))
+
+    assert order == [d, a, 1, 2, c, b, 3, 4, 5, 6]


### PR DESCRIPTION
`myia.graph_utils` should contain generic graph traversal functions like `dfs` or `toposort`. The `dfs` in `myia.anf_ir_utils` was adapted to use generic `dfs` with IR-specific successor functions.