### PR TITLE
Add node construction methods to Graph

### DIFF
--- a/myia/anf_ir.py
+++ b/myia/anf_ir.py
@@ -74,7 +74,7 @@ class Graph:
         """Create a constant for the given object."""
         return Constant(obj)
 
-    def apply(self, inputs, graph):
+    def apply(self, *inputs):
         """Create an Apply node with given inputs, bound to this graph."""
         inputs = [i if isinstance(i, ANFNode) else self.constant(i)
                   for i in inputs]

--- a/myia/anf_ir.py
+++ b/myia/anf_ir.py
@@ -64,6 +64,22 @@ class Graph:
         else:
             self.return_ = Apply([Constant(primops.return_), value], self)
 
+    def add_parameter(self):
+        """Add a new parameter to this graph (appended to the end)."""
+        p = Parameter(self)
+        self.parameters.append(p)
+        return p
+
+    def constant(self, obj):
+        """Create a constant for the given object."""
+        return Constant(obj)
+
+    def apply(self, inputs, graph):
+        """Create an Apply node with given inputs, bound to this graph."""
+        inputs = [i if isinstance(i, ANFNode) else self.constant(i)
+                  for i in inputs]
+        return Apply(inputs, self)
+
     def __str__(self) -> str:
         return self.debug.debug_name
 

--- a/myia/anf_ir.py
+++ b/myia/anf_ir.py
@@ -64,21 +64,21 @@ class Graph:
         else:
             self.return_ = Apply([Constant(primops.return_), value], self)
 
-    def add_parameter(self):
+    def add_parameter(self) -> 'Parameter':
         """Add a new parameter to this graph (appended to the end)."""
         p = Parameter(self)
         self.parameters.append(p)
         return p
 
-    def constant(self, obj):
+    def constant(self, obj: Any) -> 'Constant':
         """Create a constant for the given object."""
         return Constant(obj)
 
-    def apply(self, *inputs):
+    def apply(self, *inputs: Any) -> 'Apply':
         """Create an Apply node with given inputs, bound to this graph."""
-        inputs = [i if isinstance(i, ANFNode) else self.constant(i)
-                  for i in inputs]
-        return Apply(inputs, self)
+        wrapped_inputs = [i if isinstance(i, ANFNode) else self.constant(i)
+                          for i in inputs]
+        return Apply(wrapped_inputs, self)
 
     def __str__(self) -> str:
         return self.debug.debug_name

--- a/myia/parser.py
+++ b/myia/parser.py
@@ -141,16 +141,17 @@ class Environment:
         """
         if id(obj) in self._object_map:
             return self._object_map[id(obj)]
-        if isinstance(obj, (bool, float, int, str)):
+        elif isinstance(obj, (bool, float, int, str, primops.Primitive)):
             node = Constant(obj)
             self._object_map[id(obj)] = node
             return node
-        if isinstance(obj, FunctionType):
+        elif isinstance(obj, FunctionType):
             parser = Parser(self, obj)
             # This will insert object into the map
             parser.parse()
             return self._object_map[id(obj)]
-        raise ValueError(obj)
+        else:
+            raise ValueError(obj)
 
     def _remove(self, id: int) -> None:
         if id in self._object_map:

--- a/tests/test_anf_ir.py
+++ b/tests/test_anf_ir.py
@@ -138,6 +138,23 @@ def test_graph():
     g.parameters.append(x)
 
 
+def test_graph_helpers():
+    """Test the helper methods on graphs."""
+    g = Graph()
+    x = g.add_parameter()
+    y = g.add_parameter()
+    assert g.parameters == [x, y]
+    one = g.constant(1)
+    add = g.constant('add')
+    temp = g.apply('mul', one, 2)
+    assert temp.graph is g
+    assert all(isinstance(x, Constant) for x in temp.inputs)
+    assert list(x.value for x in temp.inputs) == ['mul', 1, 2]
+    g.output = g.apply(add, temp, x)
+    assert g.output.graph is g
+    assert list(g.output.inputs) == [add, temp, x]
+
+
 def test_graph_output():
     g = Graph()
     with pytest.raises(Exception):


### PR DESCRIPTION
This is a draft proposal to make explicit graph construction and reusing Constants easier.

* Add an `environment` attribute to `Graph`. That way, graph transforms and optimizer can easily get ahold of it and use it to build constants.
* Add `Environment.apply` to build an `Apply` node. That method could eventually implement common subexpression elimination.
* Rename `Environment.map` to `Environment.constant`, because I find it clearer, and I don't think it's meant to return non-constants.
* Add `Graph.apply`. `g.apply(primops.add, node, 1)` is the same as `Apply([g.environment.constant(primops.add), node, g.environment.constant(1)], g)`, but a lot easier to write and read.
* Add `Graph.add_parameter`, which creates a parameter for that graph and also adds it to the parameter list. The new parameter is returned.
* Add `Graph.constant` as a shortcut to `Graph.environment.constant`, for convenience.

I also hide the implementation detail that we use `id(obj)` as the key in environments, which adds the flexibility of not doing that in the future. I'll note that there is some danger with that approach, because an object's id can be reused after the GC reclaims it. In the case of functions, where the constant contains a Graph and might not contain a pointer to the original function, it is possible (although unlikely) that we'd get a collision.

Another point to discuss is whether `Environment` should use a `WeakValueDictionary`. That would allow the GC to reclaim unused constants.