### PR TITLE
Destroy disconnected nodes

### DIFF
--- a/myia/anf_ir_utils.py
+++ b/myia/anf_ir_utils.py
@@ -16,7 +16,7 @@ def succ_deep(node: ANFNode) -> Iterable[ANFNode]:
     A node's successors are its `incoming` set, or the return node of a graph
     when a graph Constant is encountered.
     """
-    if is_constant_graph(node):
+    if is_constant_graph(node) and node.value.return_:
         return [node.value.return_]
     else:
         return node.incoming
@@ -38,6 +38,8 @@ def succ_stop_at_fv(graph):
             return node.incoming
         else:
             return []
+
+    return succ
 
 
 def succ_bidirectional(scope: Set[Graph]) -> Callable:

--- a/myia/cconv.py
+++ b/myia/cconv.py
@@ -32,7 +32,8 @@ class NestingAnalyzer:
     @memoize_method
     def coverage(self) -> Iterable[Graph]:
         """Return a collection of graphs accessible from the root."""
-        nodes = dfs(Constant(self.root), succ_deep)
+        root: ANFNode = Constant(self.root)
+        nodes = dfs(root, succ_deep)
         return [node.value for node in nodes
                 if is_constant_graph(node)]
 

--- a/myia/parser.py
+++ b/myia/parser.py
@@ -48,6 +48,7 @@ from typing import \
 from weakref import finalize
 
 from myia.anf_ir import ANFNode, Parameter, Apply, Graph, Constant
+from myia.anf_ir_utils import destroy_disconnected_nodes
 from myia.info import DebugInherit, About
 from myia import primops
 
@@ -208,12 +209,15 @@ class Parser:
             # we basically just pass through them.
             return None  # pragma: no cover
 
-    def parse(self) -> Graph:
+    def parse(self, clean=True) -> Graph:
         """Parse the function into a Myia graph."""
         tree = ast.parse(textwrap.dedent(inspect.getsource(self.function)))
         function_def = tree.body[0]
         assert isinstance(function_def, ast.FunctionDef)
-        return self._process_function(None, function_def)[1].graph
+        graph = self._process_function(None, function_def)[1].graph
+        if clean:
+            destroy_disconnected_nodes(graph)
+        return graph
 
     def get_block_function(self, block: 'Block') -> Constant:
         """Return node representing the function corresponding to a block."""

--- a/tests/test_anf_ir_utils.py
+++ b/tests/test_anf_ir_utils.py
@@ -70,9 +70,10 @@ def _name_nodes(nodes):
 def test_disconnect():
     def f(x):
         a = x * x
-        _b = a + x  # Not connected to any output
+        _b = a + x  # Not connected to any output # noqa
         c = a * a
         d = c * c   # Connected to g's output
+
         def g(y):
             return d * y
         return g(c)


### PR DESCRIPTION
If there is dead code in a function, the parser will not connect the corresponding nodes to the output, but the nodes will nonetheless feature in other nodes' `uses`. This PR implements a cleanup procedure to destroy these nodes and remove them from `uses`. The cleanup procedure is called by `Parser.parse` before returning.

This is needed for `Grad` since the implementation follows `uses` to build the backpropagator graph.
