### PR TITLE
Add finalizers to purge expired objects from the environment

### DIFF
--- a/myia/api.py
+++ b/myia/api.py
@@ -10,7 +10,7 @@ from myia.vm import VM as VM_
 from myia.py_implementations import implementations
 
 
-def default_object_map() -> Dict[int, ANFNode]:
+def default_object_map() -> Dict[Any, ANFNode]:
     """Get a mapping from Python objects to nodes."""
     mapping = {
         operator.add: Constant(P.add),
@@ -36,16 +36,16 @@ def default_object_map() -> Dict[int, ANFNode]:
     for prim, impl in implementations.items():
         mapping[impl] = Constant(prim)
 
-    return {id(k): v for k, v in mapping.items()}
+    return mapping
 
 
-ENV = parser.Environment(default_object_map())
+ENV = parser.Environment(default_object_map().items())
 VM = VM_(implementations)
 
 
 def parse(func: FunctionType) -> Graph:
     """Parse a function into ANF."""
-    return parser.Parser(ENV, func).parse()
+    return ENV.map(func).value
 
 
 def run(g: Graph, args: List[Any]) -> Any:

--- a/myia/parser.py
+++ b/myia/parser.py
@@ -44,7 +44,7 @@ import textwrap
 import operator
 from types import FunctionType
 from typing import \
-    overload, Any, Dict, List, Optional, Tuple, NamedTuple
+    overload, Any, Dict, List, Optional, Tuple, NamedTuple, Iterable
 from weakref import finalize
 
 from myia.anf_ir import ANFNode, Parameter, Apply, Graph, Constant
@@ -119,17 +119,17 @@ class Environment:
 
     """
 
-    def __init__(self, object_map: Dict[int, ANFNode]) -> None:
+    def __init__(self, object_map: Iterable[Tuple[Any, ANFNode]]) -> None:
         """Construct an environment.
 
         Args:
-            object_map: The object map maps Python object id's to their
-                corresponding Myia nodes. The dictionary uses ids instead of
-                the object itself so that different objects that are equal
-                don't have to share a node.
+            object_map: The object map maps Python objects to their
+                corresponding Myia nodes.
 
         """
-        self._object_map = object_map
+        self._object_map: Dict[int, ANFNode] = dict()
+        for o, n in object_map:
+            self.insert(o, n)
 
     def map(self, obj: Any) -> ANFNode:
         """Map a Python object to an ANF node.
@@ -150,6 +150,10 @@ class Environment:
             parser.parse()
             return self._object_map[id(obj)]
         raise ValueError(obj)
+
+    def remove(self, obj: Any) -> None:
+        """Remove an object from the environment."""
+        self._remove(id(obj))
 
     def _remove(self, id: int) -> None:
         if id in self._object_map:
@@ -248,11 +252,13 @@ class Parser:
                           node: ast.FunctionDef) -> Tuple['Block', 'Block']:
         """Process a function definition and return first and final blocks."""
         function_block = Block(self)
-        # Add this mapping immediately so that recursive calls can be resolved
-        self.environment.insert(self.function,
-                                self.get_block_function(function_block))
         if block:
             function_block.preds.append(block)
+        else:
+            # Add mapping for the top level so that recursive calls can resolve
+            self.environment.insert(self.function,
+                                    self.get_block_function(function_block))
+
         function_block.mature()
         function_block.graph.debug.name = node.name
         for arg in node.args.args:

--- a/myia/parser.py
+++ b/myia/parser.py
@@ -151,10 +151,6 @@ class Environment:
             return self._object_map[id(obj)]
         raise ValueError(obj)
 
-    def remove(self, obj: Any) -> None:
-        """Remove an object from the environment."""
-        self._remove(id(obj))
-
     def _remove(self, id: int) -> None:
         if id in self._object_map:
             del self._object_map[id]

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -256,6 +256,27 @@ def test_closure(x):
     return h()
 
 
+def test_closure_recur():
+    # This cannot run with parse_compare since we need to reference the
+    # top-level function
+
+    def f(x, y):
+        return fn(x - 1, y)
+
+    def fn(x, y):
+        def g(x):
+            return x + 1
+        if x == 0:
+            return g(y)
+        else:
+            return f(x, g(y))
+
+    fn2 = parse(fn)
+    py_result = fn(1, 2)
+    myia_result = run(fn2, (1, 2))
+    assert py_result == myia_result
+
+
 @parse_compare(())
 def test_closure2():
     def g(x):


### PR DESCRIPTION
Fixes the bug where sometimes functions get mapped to the graph of a previous function that was reclaimed by the GC.