### PR TITLE
Some tool fixes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 omit =
     setup.py
+    tests/*
 
 [report]
 exclude_lines =

--- a/.pydocstyle
+++ b/.pydocstyle
@@ -1,3 +1,3 @@
 [pydocstyle]
 ignore-decorators = overload
-add-ignore = D105
+add-ignore = D105, D401


### PR DESCRIPTION
First is to stop pydocstyle judging the mood of the first line of the docstring because it does a poor job and it's mostly annoying.

Second is to exclude the tests in the coverage reports by default.