### PR TITLE
Add include argument to dfs, inclusion functions, helpers

### DIFF
--- a/myia/anf_ir_utils.py
+++ b/myia/anf_ir_utils.py
@@ -79,7 +79,6 @@ def freevars_boundary(graph, include_boundary=True):
         graph: The main graph from which we want to include nodes.
         include_boundary: Whether to yield the free variables or not.
     """
-
     def include(node):
         g = node.graph
         if g is None or g is graph:

--- a/myia/anf_ir_utils.py
+++ b/myia/anf_ir_utils.py
@@ -2,7 +2,8 @@
 from typing import Iterable, Callable, Set
 
 from myia.anf_ir import ANFNode, Apply, Constant, Graph, Parameter
-from myia.graph_utils import dfs as _dfs, toposort as _toposort
+from myia.graph_utils import dfs as _dfs, toposort as _toposort, \
+    FOLLOW, NOFOLLOW, EXCLUDE
 
 
 #######################
@@ -67,7 +68,7 @@ def exclude_from_set(stops):
         stops = frozenset(stops)
 
     def include(node):
-        return node not in stops
+        return EXCLUDE if node in stops else FOLLOW
 
     return include
 
@@ -82,11 +83,11 @@ def freevars_boundary(graph, include_boundary=True):
     def include(node):
         g = node.graph
         if g is None or g is graph:
-            return True
+            return FOLLOW
         elif include_boundary:
-            return None
+            return NOFOLLOW
         else:
-            return False
+            return EXCLUDE
 
     return include
 

--- a/myia/anf_ir_utils.py
+++ b/myia/anf_ir_utils.py
@@ -141,17 +141,17 @@ def destroy_disconnected_nodes(root: Graph) -> None:
 ##################
 
 
-def is_apply(x):
+def is_apply(x: ANFNode) -> bool:
     """Return whether x is an Apply."""
     return isinstance(x, Apply)
 
 
-def is_parameter(x):
+def is_parameter(x: ANFNode) -> bool:
     """Return whether x is a Parameter."""
     return isinstance(x, Parameter)
 
 
-def is_constant(x):
+def is_constant(x: ANFNode) -> bool:
     """Return whether x is a Constant."""
     return isinstance(x, Constant)
 

--- a/myia/graph_utils.py
+++ b/myia/graph_utils.py
@@ -5,18 +5,31 @@ the notion of successor.
 """
 
 
-from typing import Callable, Iterable, Set, TypeVar, List
+from typing import Any, Callable, Iterable, Set, TypeVar, List, Optional
 
 
 T = TypeVar('T')
 
 
-def dfs(root: T, succ: Callable[[T], Iterable[T]]) -> Iterable[T]:
+def always_include(node: Any) -> bool:
+    """Include a node in the search unconditionally."""
+    return True
+
+
+def dfs(root: T,
+        succ: Callable[[T], Iterable[T]],
+        include: Callable[[T], Optional[bool]] = always_include) \
+            -> Iterable[T]:
     """Perform a depth-first search.
 
     Arguments:
         root: The node to start from.
         succ: A function that returns a node's successors.
+        include: A function that returns whether to include a node
+                 in the search.
+            * Return True to include the node and follow its edges.
+            * Return None to include the node but not follow its edges.
+            * Return False to not include the node, nor follow its edges.
     """
     seen: Set[T] = set()
     to_visit = [root]
@@ -25,8 +38,11 @@ def dfs(root: T, succ: Callable[[T], Iterable[T]]) -> Iterable[T]:
         if node in seen:
             continue
         seen.add(node)
-        yield node
-        to_visit += succ(node)
+        incl = include(node)
+        if incl is not False:
+            yield node
+        if incl:
+            to_visit += succ(node)
 
 
 def toposort(root: T, succ: Callable[[T], Iterable[T]]) -> Iterable[T]:

--- a/myia/graph_utils.py
+++ b/myia/graph_utils.py
@@ -5,20 +5,25 @@ the notion of successor.
 """
 
 
-from typing import Any, Callable, Iterable, Set, TypeVar, List, Optional
+from typing import Any, Callable, Iterable, Set, TypeVar, List
+
+
+FOLLOW = 'follow'
+NOFOLLOW = 'nofollow'
+EXCLUDE = 'exclude'
 
 
 T = TypeVar('T')
 
 
-def always_include(node: Any) -> bool:
+def always_include(node: Any) -> str:
     """Include a node in the search unconditionally."""
-    return True
+    return FOLLOW
 
 
 def dfs(root: T,
         succ: Callable[[T], Iterable[T]],
-        include: Callable[[T], Optional[bool]] = always_include) \
+        include: Callable[[T], str] = always_include) \
             -> Iterable[T]:
     """Perform a depth-first search.
 
@@ -27,9 +32,9 @@ def dfs(root: T,
         succ: A function that returns a node's successors.
         include: A function that returns whether to include a node
                  in the search.
-            * Return True to include the node and follow its edges.
-            * Return None to include the node but not follow its edges.
-            * Return False to not include the node, nor follow its edges.
+            * Return 'follow' to include the node and follow its edges.
+            * Return 'nofollow' to include the node but not follow its edges.
+            * Return 'exclude' to not include the node, nor follow its edges.
     """
     seen: Set[T] = set()
     to_visit = [root]
@@ -39,10 +44,17 @@ def dfs(root: T,
             continue
         seen.add(node)
         incl = include(node)
-        if incl is not False:
+        if incl == FOLLOW:
             yield node
-        if incl:
             to_visit += succ(node)
+        elif incl == NOFOLLOW:
+            yield node
+        elif incl == EXCLUDE:
+            pass
+        else:
+            raise ValueError('include(node) must return one of: '
+                             '"follow", "nofollow", "exclude"') \
+                # pragma: no cover
 
 
 def toposort(root: T, succ: Callable[[T], Iterable[T]]) -> Iterable[T]:


### PR DESCRIPTION
* Add an `include` argument to `dfs` that allows controlling which nodes should be followed (default is to follow every node).

* Add two inclusion functions: `exclude_from_set` to stop the search when certain nodes are encountered, and `freevars_boundary` to stop the search when free variables are encountered.

* Add `succ_deeper`, which also visits the graphs encountered through free variables starting from their roots. This fixes some blind spots in `NestingAnalyzer`.

* Add `is_apply`, `is_constant` as helper functions to check what type of node we are dealing with. I find this more practical than `isinstance`.
