### PR TITLE
Graph cloning

### DIFF
--- a/myia/cconv.py
+++ b/myia/cconv.py
@@ -152,6 +152,21 @@ class NestingAnalyzer:
         return children
 
     @memoize_method
+    def scopes(self) -> Dict[Graph, Set[Graph]]:
+        """Map each graph to the complete set of graphs nested in it.
+
+        The set associated to a graph includes the graph.
+        """
+        parents = self.parents()
+        scopes: Dict[Graph, Set[Graph]] = defaultdict(set)
+        for g in self.coverage():
+            p = g
+            while p:
+                scopes[p].add(g)
+                p = parents[p]
+        return scopes
+
+    @memoize_method
     def free_variables_total(self) -> Dict[Graph, Set[ANFNode]]:
         """Map each graph to its free variables.
 

--- a/myia/clone.py
+++ b/myia/clone.py
@@ -1,0 +1,227 @@
+"""Graph cloning facility."""
+
+
+from typing import Any, Iterable, Dict, Union, Set, cast
+from myia.cconv import NestingAnalyzer
+from myia.info import About
+from myia.anf_ir import ANFNode, Apply, Parameter, Constant, Graph
+from myia.graph_utils import dfs
+from myia.anf_ir_utils import \
+    succ_incoming, exclude_from_set, \
+    is_parameter, is_constant
+from myia.utils import smap
+
+
+#################
+# Graph cloning #
+#################
+
+
+class GraphCloner:
+    """Facility to clone graphs.
+
+    Graphs to clone can be passed in the constructor or they can be
+    added with the `add_clone` method, which offers more options.
+
+    Cloning a graph automatically involves cloning every graph which
+    is nested in it.
+
+    To get the clone of a graph, index the GraphCloner with the graph,
+    e.g. `cloned_g = graph_cloner[g]`
+
+    Attributes:
+        total: Whether to clone every graph encountered when walking
+            through the graphs to clone, even if these graphs are
+            not nested.
+        clone_constants: Whether to clone Constant nodes.
+        relation: The relation the cloned nodes present with respect
+            to the originals, for debugging purposes. Default is
+            'copy'.
+
+    """
+
+    def __init__(self,
+                 *graphs: Graph,
+                 total: bool = False,
+                 clone_constants: bool = False,
+                 relation: str = 'copy') -> None:
+        """Initialize a GraphCloner."""
+        self.todo: Set[Graph] = set()
+        self.graph_mappings: Dict[Graph, Union[Graph, bool]] = {}
+        self.repl: Dict[Union[Graph, ANFNode],
+                        Union[Graph, ANFNode]] = {None: None}
+        self.total = total
+        self.clone_constants = clone_constants
+        self.relation = relation
+        for graph in graphs:
+            self.add_clone(graph)
+
+    def _add_clone(self,
+                   graph: Graph,
+                   target_graph: Graph = None,
+                   set_output: bool = None) -> Graph:
+        """Register a clone for the given graph.
+
+        This does not register graphs nested in the given graph, so
+        use this method with caution.
+
+        Arguments:
+            graph: The graph to clone.
+            target_graph: The graph which will contain the clones of
+                the nodes in the original graph. If target_graph is
+                None or not given, a new Graph will be created to
+                serve as the target_graph.
+            set_output: Whether the output of the target_graph should
+                be set to the clone of the output of the original
+                graph. If set_output is None or not given, then it
+                is true if target_graph is None (and thus must be
+                created), false otherwise.
+
+        Return:
+            target_graph, or the clone associated to the original graph.
+        """
+        if set_output is None:
+            set_output = target_graph is None
+
+        if target_graph is None:
+            with About(graph.debug, self.relation):
+                target_graph = Graph()
+
+        self.repl[graph] = target_graph
+        if set_output:
+            self.graph_mappings[graph] = target_graph
+        else:
+            self.graph_mappings[graph] = True
+        self.todo.add(graph)
+
+        return target_graph
+
+    def add_clone(self,
+                  graph: Graph,
+                  target_graph: Graph = None,
+                  new_params: Iterable[ANFNode] = None,
+                  set_output: bool = None):
+        """Add a clone for the given graph.
+
+        This method can also be used for inlining.
+
+        Any graph nested in the given graph will also be cloned.
+
+        Arguments:
+            graph: The original graph, which we want to clone. Graphs
+                nested in the original graph will be automatically cloned.
+            target_graph: The graph in which to place clones of the nodes
+                in the original graph. If target_graph is None or not given,
+                a fresh Graph will be created automatically.
+            new_params: A list of nodes to serve as the new parameters of
+                the cloned graph, if the goal is inlining.
+            set_output: Whether the output of the target_graph should
+                be set to the clone of the output of the original
+                graph. If set_output is None or not given, then it
+                is true if target_graph is None (and thus must be
+                created), false otherwise (because the intent is most
+                likely inlining into target_graph, and you don't want
+                to set the output in this case).
+        """
+        nest = NestingAnalyzer(graph)
+        nested_graphs = nest.scopes()[graph]
+        for g in nested_graphs:
+            if g is not graph:
+                self._add_clone(g)
+
+        self._add_clone(graph, target_graph, set_output)
+
+        if new_params:
+            for p, new_p in zip(graph.parameters, new_params):
+                self.repl[p] = new_p
+
+    def _get_graph(self, g: Graph) -> Graph:
+        if self.total and g not in self.repl:
+            # When the total option is given, we clone any new graph
+            # we encounter.
+            self._add_clone(g)
+        # When the total option is not given, we do not clone graphs
+        # unless specified explicitly.
+        g2 = self.repl.get(g, g)
+        return cast(Graph, g2)
+
+    def _clone_subgraph(self, root: ANFNode) -> ANFNode:
+        """Helper function to clone starting from root.
+
+        Arguments:
+            root: The starting point for the cloning.
+
+        Return: The clone of root.
+        """
+        to_clone = list(dfs(root,
+                            succ_incoming,
+                            exclude_from_set(self.repl)))
+
+        for node in to_clone:
+            assert node not in self.repl
+            g = self._get_graph(node.graph)
+            if g and g is node.graph:
+                self.repl[node] = node
+                continue
+
+            new: ANFNode
+            with About(node.debug, self.relation):
+                if is_parameter(node):
+                    new = Parameter(g)
+                elif is_constant(node):
+                    def convert(x):
+                        if isinstance(x, Graph):
+                            if self.graph_mappings.get(x, x) is True:
+                                if self.total:
+                                    raise Exception(
+                                        '`total` option is not compatible'
+                                        ' with inlining.'
+                                    )
+                                else:
+                                    return x
+                            return self._get_graph(x)
+                        else:
+                            return x
+                    # This will also properly handle e.g. tuples of graphs
+                    new_value = smap(convert, node.value)
+                    if new_value is node.value and not self.clone_constants:
+                        new = node
+                    else:
+                        new = Constant(new_value)
+                else:
+                    new = Apply([], g)
+            self.repl[node] = new
+
+        for _node in to_clone:
+            node = cast(ANFNode, _node)
+            new_inputs = [self.repl[orig_node] for orig_node in node.inputs]
+            repl = cast(ANFNode, self.repl[node])
+            repl.inputs = new_inputs  # type: ignore
+
+        return cast(ANFNode, self.repl[root])
+
+    def run(self) -> None:
+        """Clone everything still to be cloned.
+
+        It is not necessary to run this method, because `getitem` runs
+        it automatically.
+        """
+        while self.todo:
+            graph = self.todo.pop()
+            new_graph = self.graph_mappings[graph]
+            root = graph.output
+            new_root = self._clone_subgraph(root)
+            if isinstance(new_graph, Graph):
+                new_graph.output = new_root
+                assert all(is_parameter(p) for p in graph.parameters)
+                new_graph.parameters = [cast(Parameter, self.repl[p])
+                                        for p in graph.parameters]
+
+    def __getitem__(self, x: Any) -> Any:
+        """Get the clone of the given graph."""
+        self.run()
+        if isinstance(x, Graph) \
+                and self.graph_mappings.get(x, x) is True:
+            return x
+        else:
+            return self.repl.get(x, x)

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -1,0 +1,204 @@
+
+import pytest
+from myia.api import parse
+from myia.graph_utils import dfs
+from myia.anf_ir import Graph, Constant
+from myia.anf_ir_utils import succ_deeper, succ_incoming, is_constant
+from myia.clone import GraphCloner
+from myia.debug.label import Index
+from myia.prim import ops as primops
+
+
+def test_clone_simple():
+    def f(x, y):
+        a = x * x
+        b = y * y
+        c = a + b
+        return c
+
+    g = parse(f)
+
+    cl = GraphCloner(g, clone_constants=True)
+
+    g2 = cl[g]
+
+    d1 = set(dfs(g.return_, succ_deeper))
+    d2 = set(dfs(g2.return_, succ_deeper))
+
+    # Both node sets should be disjoint
+    assert d1 & d2 == set()
+
+    # Without cloning constants
+    cl2 = GraphCloner(g, clone_constants=False)
+
+    g2 = cl2[g]
+
+    d1 = set(dfs(g.return_, succ_deeper))
+    d2 = set(dfs(g2.return_, succ_deeper))
+
+    common = d1 & d2
+    assert all(is_constant(x) for x in common)
+    assert {x.value for x in common} == {primops.add, primops.mul}
+
+
+def test_clone_closure():
+    def f(x, y):
+        def j(z):
+            a = x + y
+            b = a + z
+            return b
+        c = j(3)
+        return c
+
+    parsed_f = parse(f)
+    idx = Index(parsed_f)
+    g = idx['j']
+
+    cl = GraphCloner(g, clone_constants=True)
+    idx2 = Index(cl[g], succ=succ_incoming)
+
+    for name in 'xy':
+        assert idx[name] is idx2[name]
+    for name in 'zabj':
+        assert idx[name] is not idx2[name]
+
+
+def test_clone_scoping():
+    def f(x, y):
+        def g():
+            # Depends on f, therefore cloned
+            return x + y
+
+        def h(z):
+            # No dependency on f, so not nested and not cloned
+            return z * z
+
+        def i(q):
+            # Depends on f, therefore cloned
+            return g() * q
+        return g() + h(x) + i(y)
+
+    g = parse(f)
+
+    cl = GraphCloner(g, clone_constants=True)
+
+    g2 = cl[g]
+
+    idx1 = Index(g)
+    idx2 = Index(g2)
+
+    for name in 'fgi':
+        assert idx1[name] is not idx2[name]
+    for name in 'h':
+        assert idx1[name] is idx2[name]
+
+
+def test_clone_total():
+    def f1(x):
+        return x * x
+
+    def f2(y):
+        return f1(y) + 3
+
+    g = parse(f2)
+    idx0 = Index(g)
+
+    cl1 = GraphCloner(g, clone_constants=True, total=True)
+    idx1 = Index(cl1[g])
+    assert idx1['f2'] is not idx0['f2']
+    assert idx1['f1'] is not idx0['f1']
+
+    cl2 = GraphCloner(g, clone_constants=True, total=False)
+    idx2 = Index(cl2[g])
+    assert idx2['f2'] is not idx0['f2']
+    assert idx2['f1'] is idx0['f1']
+
+
+ONE = Constant(1)
+TWO = Constant(2)
+THREE = Constant(3)
+
+
+def _graph_for_inline():
+    target = Graph()
+    target.debug.name = 'target'
+    target.output = THREE
+    return target
+
+
+def _successful_inlining(cl, orig, new_params, target):
+    assert cl[orig] is not target
+    assert cl[orig] is orig
+
+    new_root = cl[orig.output]
+    assert new_root is not orig.output
+
+    orig_nodes = set(dfs(orig.output, succ_incoming))
+    new_nodes = set(dfs(new_root, succ_incoming))
+
+    for p in new_params:
+        assert p in new_nodes
+
+    # Clones of orig's nodes should belong to target
+    assert all(cl[node].graph in {target, None}
+               for node in orig_nodes
+               if node.graph is orig)
+
+    # Clone did not change target
+    assert target.output is THREE
+
+
+def test_clone_inline():
+    def f(x, y):
+        a = x * x
+        b = y * y
+        c = a + b
+        return c
+
+    g = parse(f)
+
+    cl = GraphCloner(clone_constants=False)
+    target = _graph_for_inline()
+    new_params = [ONE, TWO]
+    cl.add_clone(g, target, new_params, False)
+
+    _successful_inlining(cl, g, new_params, target)
+
+
+def test_clone_recursive():
+    def f(x, y):
+        a = x * x
+        b = y * y
+        return f(a, b)
+
+    g = parse(f)
+
+    cl = GraphCloner(g, clone_constants=True)
+
+    g2 = cl[g]
+
+    d1 = set(dfs(g.return_, succ_deeper))
+    d2 = set(dfs(g2.return_, succ_deeper))
+
+    # Both node sets should be disjoint
+    assert d1 & d2 == set()
+
+    # Now test inlining
+    cl2 = GraphCloner(clone_constants=True)
+    target = _graph_for_inline()
+    new_params = [ONE, TWO]
+    cl2.add_clone(g, target, new_params, False)
+
+    _successful_inlining(cl2, g, new_params, target)
+
+    # The recursive call still refers to the original graph
+    new_nodes = set(dfs(cl2[g.output], succ_deeper))
+    assert any(node.value is g for node in new_nodes)
+
+    # Now test that inlining+total will fail
+    cl2 = GraphCloner(total=True, clone_constants=True)
+    target = _graph_for_inline()
+    new_params = [ONE, TWO]
+    with pytest.raises(Exception):
+        cl2.add_clone(g, target, new_params, False)
+        cl2[g.output]


### PR DESCRIPTION
Cloning graphs is necessary in several situations, like inlining a graph in another, or creating a graph that can be modified without changing the original. This implements graph cloning with the `GraphCloner` class, which has the following features:

* Multiple graphs can be cloned together. If a graph is cloned, all references to the original, in all cloned graphs, will be replaced by references to the clone.
* Cloning a graph also clones every graph that's nested in it. This required a new method in `NestingAnalyzer` called `scopes`.
* For inlining, a host graph and a list of new parameters can be specified for the clone of a graph.
* The optional `total` option will trigger cloning of every encountered graph, guaranteeing that the clone and the original are completely disjoint.

I believe this corresponds to the "lambda mangling" algorithm described in the Thorin paper.

I also put some utilities in `myia.debug.label` that are useful for writing tests. For example, `myia.debug.label.Index(graph)` creates a mapping from node/graph names to nodes/graphs, so that you can parse a Python function and easily check the node corresponding to an inner function or a variable by name. This is used extensively in the tests for `GraphCloner`.

Note: this PR includes #45, which should be merged before this one.