### PR TITLE
Add include argument to toposort

### DIFF
--- a/myia/graph_utils.py
+++ b/myia/graph_utils.py
@@ -57,13 +57,19 @@ def dfs(root: T,
                 # pragma: no cover
 
 
-def toposort(root: T, succ: Callable[[T], Iterable[T]]) -> Iterable[T]:
+def toposort(root: T,
+             succ: Callable[[T], Iterable[T]],
+             include: Callable[[T], str] = always_include) -> Iterable[T]:
     """Yield the nodes in the tree starting at root in topological order.
 
     Arguments:
         root: The node to start from.
         succ: A function that returns a node's successors.
-
+        include: A function that returns whether to include a node
+                 in the search.
+            * Return 'follow' to include the node and follow its edges.
+            * Return 'nofollow' to include the node but not follow its edges.
+            * Return 'exclude' to not include the node, nor follow its edges.
     """
     done: Set[T] = set()
     todo: List[T] = [root]
@@ -74,10 +80,24 @@ def toposort(root: T, succ: Callable[[T], Iterable[T]]) -> Iterable[T]:
             todo.pop()
             continue
         cont = False
-        for i in succ(node):
-            if i not in done:
-                todo.append(i)
-                cont = True
+
+        incl = include(node)
+        if incl == FOLLOW:
+            for i in succ(node):
+                if i not in done:
+                    todo.append(i)
+                    cont = True
+        elif incl == NOFOLLOW:
+            pass
+        elif incl == EXCLUDE:
+            done.add(node)
+            todo.pop()
+            continue
+        else:
+            raise ValueError('include(node) must return one of: '
+                             '"follow", "nofollow", "exclude"') \
+                # pragma: no cover
+
         if cont:
             continue
         done.add(node)

--- a/myia/graph_utils.py
+++ b/myia/graph_utils.py
@@ -5,7 +5,7 @@ the notion of successor.
 """
 
 
-from typing import Any, Callable, Iterable, Set, TypeVar, List
+from typing import Any, Callable, Iterable, Set, TypeVar, List, Dict
 
 
 FOLLOW = 'follow'
@@ -73,12 +73,16 @@ def toposort(root: T,
     """
     done: Set[T] = set()
     todo: List[T] = [root]
+    rank: Dict[T, int] = {}
 
     while todo:
         node = todo[-1]
         if node in done:
             todo.pop()
             continue
+        if node in rank and rank[node] != len(todo):
+            raise ValueError('cycle')
+        rank[node] = len(todo)
         cont = False
 
         incl = include(node)

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -1,5 +1,6 @@
 """Test generic graph utilities."""
 
+import pytest
 from myia.graph_utils import dfs, toposort, FOLLOW, NOFOLLOW, EXCLUDE
 
 
@@ -83,3 +84,19 @@ def test_toposort_incl():
 
     order2 = list(toposort(c, _succ, _incl_x))
     _check_toposort(order2, c, _succ, _incl_x)
+
+
+def test_toposort_cycle():
+    class Q:
+        def __init__(self, x, y):
+            self.x = x
+            self.y = y
+
+    def qsucc(q):
+        return [q.x, q.y]
+
+    q = Q(1, 2)
+    q.y = q
+
+    with pytest.raises(ValueError):
+        list(toposort(q, qsucc, _incl))

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -35,7 +35,7 @@ def test_dfs_dups():
 
 def _check_toposort(order, root, succ=_succ, incl=_incl):
     nodes = set(dfs(root, succ, incl))
-    assert len(order) == len(nodes)
+    assert set(order) == nodes
     for node in nodes:
         for i in succ(node):
             if i in order:

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -1,10 +1,14 @@
 """Test generic graph utilities."""
 
-from myia.graph_utils import dfs, toposort
+from myia.graph_utils import dfs, toposort, FOLLOW, NOFOLLOW, EXCLUDE
 
 
 def _succ(x):
     return reversed(x) if isinstance(x, tuple) else ()
+
+
+def _incl(x):
+    return FOLLOW
 
 
 def test_dfs():
@@ -29,22 +33,23 @@ def test_dfs_dups():
     assert order == [d, a, 1, 2, c, b, 3, 4, 5, 6]
 
 
-def _check_toposort(order, root, succ):
-    nodes = set(dfs(root, succ))
+def _check_toposort(order, root, succ=_succ, incl=_incl):
+    nodes = set(dfs(root, succ, incl))
     assert len(order) == len(nodes)
     for node in nodes:
         for i in succ(node):
-            assert order.index(i) < order.index(node)
+            if i in order:
+                assert order.index(i) < order.index(node)
 
 
 def test_toposort():
     a = (1, 2)
     b = (3, 4, 5)
-    c = (b, 6)
+    c = (b, a, 6)
     d = (a, c)
 
-    order = list(toposort(d, _succ))
-    _check_toposort(order, d, _succ)
+    order = list(toposort(d, _succ, _incl))
+    _check_toposort(order, d, _succ, _incl)
 
 
 def test_toposort_overlap():
@@ -52,5 +57,29 @@ def test_toposort_overlap():
     b = (a, 2)
     c = (b, a, 2)
 
-    order = list(toposort(c, _succ))
-    _check_toposort(order, c, _succ)
+    order = list(toposort(c, _succ, _incl))
+    _check_toposort(order, c, _succ, _incl)
+
+
+def test_toposort_incl():
+    def _incl_nf(x):
+        if isinstance(x, tuple) and len(x) == 2:
+            return NOFOLLOW
+        else:
+            return FOLLOW
+
+    def _incl_x(x):
+        if isinstance(x, tuple) and len(x) == 2:
+            return EXCLUDE
+        else:
+            return FOLLOW
+
+    a = (1, 2)
+    b = (a, 3)
+    c = (a, b, 4, 5)
+
+    order1 = list(toposort(c, _succ, _incl_nf))
+    _check_toposort(order1, c, _succ, _incl_nf)
+
+    order2 = list(toposort(c, _succ, _incl_x))
+    _check_toposort(order2, c, _succ, _incl_x)


### PR DESCRIPTION
This modifies `toposort` to have the same interface as `dfs`. This enables, for example, excluding nodes from a parent graph from the toposort (which is fine, since it is always valid to order the nodes from a parent graph before those of the current graph). This was initially part of #52.