### PR TITLE
Add intersection method to Var

### DIFF
--- a/myia/unify.py
+++ b/myia/unify.py
@@ -459,6 +459,8 @@ class Unification:
             u = v.intersection(w)
             if u is NotImplemented:
                 u = w.intersection(v)
+            if u is False:
+                raise UnificationError("Incompatible variables")
             if u is not NotImplemented:
                 assert isinstance(u, Var)
                 if u is not v:

--- a/tests/test_unify.py
+++ b/tests/test_unify.py
@@ -411,6 +411,23 @@ def test_unify():
     assert TU.unify(None, 0) is None
 
 
+def test_unify_restrictedvars():
+    v1 = RestrictedVar((1, 2))
+    v2 = RestrictedVar((2, 3))
+    v3 = RestrictedVar((3, 4))
+
+    d = TU.unify((v1, v2), (v2, v1))
+    assert d
+
+    vx = d[v1]
+    assert vx is not v1
+    assert vx is not v2
+    assert vx is d[v2]
+    assert vx.legal_values == (2,)
+
+    assert not TU.unify(v1, v3)
+
+
 def test_unify_filtervars():
 
     def floats(v):


### PR DESCRIPTION
This makes unification more powerful by allowing the unification of two RestrictedVars using the intersection of their legal values, and the unification of two FilterVars using the conjunction of their filters/predicates.