### PR TITLE
Sync pytest-cov with codecov for ignored files.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 omit =
     setup.py
     tests/*
+    myia/debug/*
 
 [report]
 exclude_lines =


### PR DESCRIPTION
For the record I don't think we should ignore myia/debug, but I believe that we should always keep codecov and pytest-cov in sync.
