### PR TITLE
Type inference

### DIFF
--- a/myia/debug/gprint.py
+++ b/myia/debug/gprint.py
@@ -7,6 +7,7 @@ from hrepr import hrepr
 
 from ..cconv import NestingAnalyzer, ParentProxy
 from ..dtype import Type, Bool, Int, Float, Tuple, List, Function
+from ..infer import Reference
 from ..info import DebugInfo, About
 from ..ir import ANFNode, Apply, Constant, Graph, is_apply, is_constant, \
     is_constant_graph, is_parameter, is_special, GraphCloner
@@ -535,6 +536,12 @@ class _Apply:
 ########
 # Misc #
 ########
+
+
+@mixin(Reference)
+class _Reference:
+    def __hrepr__(self, H, hrepr):
+        return hrepr({'node': self.node, 'context': self.context})
 
 
 @mixin(Location)

--- a/myia/infer.py
+++ b/myia/infer.py
@@ -11,7 +11,13 @@ from .cconv import NestingAnalyzer
 ANYTHING = Named('ANYTHING')
 
 
-class MyiaTypeError(Exception):
+class InferenceError(Exception):
+    """Inference error in a Myia program."""
+
+    pass
+
+
+class MyiaTypeError(InferenceError):
     """Type error in a Myia program."""
 
     pass
@@ -557,7 +563,7 @@ class InferenceEngine:
             argrefs = [self.ref(node, ctx) for node in n_args]
             try:
                 return await inf(*argrefs)
-            except MyiaTypeError as e:
+            except InferenceError as e:
                 self.log_error([ref], e)
                 raise
             except RuntimeError as e:
@@ -633,13 +639,13 @@ class InferenceEngine:
                 e.g. References.
             err: Can be one of:
                 * An exception.
-                * A string to wrap as a MyiaTypeError.
+                * A string to wrap as an InferenceError.
                 * A future. If the future failed due to an exception,
                   the exception is logged, otherwise the method returns
                   without doing anything.
         """
         if isinstance(err, str):
-            err = MyiaTypeError(err)
+            err = InferenceError(err)
         elif isinstance(err, asyncio.Future):
             err = err.exception()
             if err is None:
@@ -677,7 +683,7 @@ class InferenceEngine:
             )
             if not done:
                 self.log_error(
-                    [], MyiaTypeError(
+                    [], InferenceError(
                         f'Exceeded timeout ({self.timeout}s) in type inferrer.'
                         ' There might be an infinite loop in the program,'
                         ' or the program is too large and you should'

--- a/myia/infer.py
+++ b/myia/infer.py
@@ -99,6 +99,7 @@ class PrimitiveInferrer(Inferrer):
         inferrer function.
         """
         return isinstance(other, PrimitiveInferrer) \
+            and other.nargs == self.nargs \
             and other.inferrer_fn == self.inferrer_fn
 
 
@@ -222,6 +223,7 @@ class Context:
             and self.parts == other.parts
 
     def __or__(self, other):
+        assert isinstance(other, set)
         return Context(self.engine, self.parts | other)
 
 

--- a/myia/infer.py
+++ b/myia/infer.py
@@ -165,6 +165,23 @@ class GraphInferrer(Inferrer):
             and other.context == self.context
 
 
+def register_inferrer(*prims, nargs, constructors):
+    """Define a PrimitiveInferrer for prims with nargs arguments.
+
+    For each primitive, this registers a constructor for a PrimitiveInferrer
+    that takes an engine argument, in the constructors dictionary.
+    """
+    def deco(fn):
+        def make_constructor(prim):
+            def constructor(engine):
+                return PrimitiveInferrer(engine, prim, nargs, fn)
+            return constructor
+        for prim in prims:
+            constructors[prim] = make_constructor(prim)
+        return fn
+    return deco
+
+
 ##############
 # References #
 ##############

--- a/myia/infer.py
+++ b/myia/infer.py
@@ -242,6 +242,9 @@ class Reference:
         g = node.value if is_constant_graph(node) else node.graph
         self.context = context.filter(g)
 
+    def __getitem__(self, track):
+        return self.context.engine.get(track, self)
+
     def __eq__(self, other):
         return isinstance(other, Reference) \
             and self.node is other.node \
@@ -265,6 +268,9 @@ class VirtualReference:
     def __init__(self, **values):
         """Initialize the VirtualReference."""
         self.values = values
+
+    def __getitem__(self, track):
+        return self.values[track]
 
 
 ########
@@ -476,7 +482,7 @@ class InferenceEngine:
         """Compute the value of the Reference on the given track."""
         if isinstance(ref, VirtualReference):
             # A VirtualReference already contains the values we need.
-            return ref.values[track]
+            return ref[track]
 
         node = ref.node
         ctx = ref.context

--- a/myia/infer.py
+++ b/myia/infer.py
@@ -20,6 +20,7 @@ class MyiaTypeError(Exception):
 
 
 def type_error_nargs(ident, expected, got):
+    """Return a MyiaTypeError for number of arguments mismatch."""
     return MyiaTypeError(
         f'Wrong number of arguments for {ident}:'
         f' expected {expected}, got {got}.'

--- a/myia/infer.py
+++ b/myia/infer.py
@@ -1,0 +1,507 @@
+
+import asyncio
+
+from .dtype import Int, Bool, Float, Tuple, List
+from .prim import ops as P, Primitive
+from .ir import Graph, Constant, \
+    is_constant, is_constant_graph, is_apply, is_parameter
+from .utils import Named, Registry
+from .cconv import NestingAnalyzer
+from .prim.py_implementations import implementations as pyimpl
+
+
+ANYTHING = Named('ANYTHING')
+
+
+class MyiaTypeError(Exception):
+    pass
+
+
+def typeof(v):
+    if isinstance(v, bool):
+        return Bool()
+    elif isinstance(v, int):
+        return Int(64)
+    elif isinstance(v, float):
+        return Float(64)
+    elif isinstance(v, tuple):
+        return Tuple(map(typeof, v))
+    else:
+        raise TypeError(f'Untypable value: {v}')
+
+
+####################
+# Inferrer classes #
+####################
+
+
+class Inferrer:
+    def __init__(self, engine):
+        self.engine = engine
+        self.cache = {}
+
+    async def __call__(self, *args):
+        if args not in self.cache:
+            self.cache[args] = await self.infer(*args)
+        return self.cache[args]
+
+
+class PrimitiveInferrer(Inferrer):
+    def __init__(self, engine, track, prim, inferrer_fn):
+        super().__init__(engine)
+        self.track = track
+        self.prim = prim
+        self.inferrer_fn = inferrer_fn
+
+    def infer(self, *args):
+        return self.inferrer_fn(self.engine, *args)
+
+    def provably_equivalent(self, other):
+        return isinstance(other, PrimitiveInferrer) \
+            and other.track == self.track \
+            and other.inferrer_fn == self.inferrer_fn
+
+
+class GraphInferrer(Inferrer):
+    def __init__(self, engine, track, graph, context):
+        super().__init__(engine)
+        self.track = track
+        self.graph = graph
+        self.context = context.filter(graph)
+
+    async def infer(self, *args):
+        engine = self.engine
+        argvals = {
+            track: await asyncio.gather(
+                *[engine.get(track, arg) for arg in args],
+                loop=engine.loop
+            )
+            for track in engine.tracks
+        }
+
+        gsigs = {(self.graph, track, tuple(argvals[track]))
+                 for track in engine.tracks}
+        context = self.context | gsigs
+
+        for track, vals in argvals.items():
+            for p, v in zip(self.graph.parameters, vals):
+                ref = Reference(p, context)
+                engine.cache_value(track, ref, v)
+
+        out = Reference(self.graph.output, context)
+        return await engine.get(self.track, out)
+
+    def provably_equivalent(self, other):
+        return isinstance(other, GraphInferrer) \
+            and other.track == self.track \
+            and other.graph == self.graph \
+            and other.context == self.context
+
+
+def primitive_inferrer(track, prim):
+    def wrap(fn):
+        p = lambda engine: PrimitiveInferrer(engine, track, prim, fn)
+        all_inferrers[track].register(prim)(p)
+        return p
+    return wrap
+
+
+def value_inferrer(prim):
+    async def infer(engine, *refs):
+        coros = [engine.get('value', ref) for ref in refs]
+        args = await asyncio.gather(*coros, loop=engine.loop)
+        if any(arg is ANYTHING for arg in args):
+            return ANYTHING
+        else:
+            return pyimpl[prim](*args)
+
+    return primitive_inferrer('value', prim)(infer)
+
+
+#############
+# Inferrers #
+#############
+
+
+all_inferrers = {
+    'value': Registry(),
+    'type': Registry()
+}
+
+
+@primitive_inferrer('value', Constant)
+async def infer_value_constant(engine, ct):
+    v = ct.node.value
+    if isinstance(v, Primitive):
+        vinfs = all_inferrers['value']
+        if v in vinfs:
+            return vinfs[v](engine)
+        else:
+            return value_inferrer(v)(engine)
+    elif isinstance(v, Graph):
+        return GraphInferrer(engine, 'value', v, ct.context)
+    else:
+        return v
+
+
+@primitive_inferrer('value', P.if_)
+async def infer_value_if(engine, cond, tb, fb):
+    v = await engine.get('value', cond)
+    if v is True:
+        fn = await engine.get('value', tb)
+    elif v is False:
+        fn = await engine.get('value', fb)
+    elif v is ANYTHING:
+        return ANYTHING
+
+    return await fn()
+
+
+@primitive_inferrer('type', Constant)
+async def infer_type_constant(engine, ct):
+    v = ct.node.value
+    if isinstance(v, Primitive):
+        return all_inferrers['type'][v](engine)
+    elif isinstance(v, Graph):
+        return GraphInferrer(engine, 'type', v, ct.context)
+    else:
+        return typeof(ct.node.value)
+
+
+@primitive_inferrer('type', P.if_)
+async def infer_type_if(engine, cond, tb, fb):
+    assert await engine.get('type', cond) == Bool()
+    v = await engine.get('value', cond)
+    tb_res = (await engine.get('type', tb))()
+    fb_res = (await engine.get('type', fb))()
+    if v is True:
+        return await tb_res
+    elif v is False:
+        return await fb_res
+    elif v is ANYTHING:
+        return await engine.force_same('type', tb_res, fb_res)
+
+
+@primitive_inferrer('type', P.cons_tuple)
+async def infer_type_cons_tuple(engine, x, y):
+    x_t = await engine.get('type', x)
+    y_t = await engine.get('type', y)
+    assert isinstance(y_t, Tuple)
+    return Tuple([x_t, *y_t.elements])
+
+
+@primitive_inferrer('type', P.getitem)
+async def infer_type_getitem(engine, seq, idx):
+    seq_t = await engine.get('type', seq)
+    idx_t = await engine.get('type', idx)
+    if not isinstance(idx_t, Int):
+        raise MyiaTypeError('Expected Int for index')
+
+    if isinstance(seq_t, Tuple):
+        idx_v = await engine.get('value', idx)
+        assert idx_v is not ANYTHING
+        return seq_t.elements[idx_v]
+    elif isinstance(seq_t, List):
+        return seq_t.element_type
+    else:
+        raise MyiaTypeError('Wrong seq type for getitem')
+
+
+async def infer_type_compare_bin(engine, x, y):
+    t = await engine.force_same('type', x, y)
+    if not isinstance(t, (Int, Float)):
+        raise MyiaTypeError('Expected number')
+    return Bool()
+
+
+async def infer_type_arith_bin(engine, x, y):
+    t = await engine.force_same('type', x, y)
+    if not isinstance(t, (Int, Float)):
+        raise MyiaTypeError('Expected number')
+    return t
+
+
+for op in [P.add, P.sub, P.mul]:
+    all_inferrers['type'].register(op)(
+        lambda engine: PrimitiveInferrer(
+            engine, 'type', op, infer_type_arith_bin
+        )
+    )
+
+for op in [P.lt, P.gt, P.eq, P.le, P.ge]:
+    all_inferrers['type'].register(op)(
+        lambda engine: PrimitiveInferrer(
+            engine, 'type', op, infer_type_compare_bin
+        )
+    )
+
+
+##############
+# References #
+##############
+
+
+class Context:
+    def __init__(self, engine, parts):
+        self.engine = engine
+        self.parts = frozenset(parts)
+
+    def filter(self, graph):
+        if graph is None:
+            return Context(self.engine, ())
+        deps = self.engine.deps[graph]
+        return Context(
+            self.engine,
+            ((g, track, argsig)
+             for (g, track, argsig) in self.parts
+             if g in deps or g is graph)
+        )
+
+    def __iter__(self):
+        return iter(self.parts)
+
+    def __hash__(self):
+        return hash((self.engine, self.parts))
+
+    def __eq__(self, other):
+        return type(other) is Context \
+            and self.engine == other.engine \
+            and self.parts == other.parts
+
+    def __or__(self, other):
+        return Context(self.engine, self.parts | other)
+
+
+class Reference:
+    def __init__(self, node, context):
+        self.node = node
+        g = node.value if is_constant_graph(node) else node.graph
+        self.context = context.filter(g)
+
+    def __eq__(self, other):
+        return isinstance(other, Reference) \
+            and self.node is other.node \
+            and self.context == other.context
+
+    def __hash__(self):
+        return hash((self.node, self.context))
+
+    def __hrepr__(self, H, hrepr):
+        return hrepr({'node': self.node, 'context': self.context})
+
+
+class VirtualReference:
+    def __init__(self, **values):
+        self.values = values
+
+
+########
+# Core #
+########
+
+
+class InferrerEquivalenceClass:
+
+    def __init__(self, engine, members):
+        self.engine = engine
+        self.checked_members = set()
+        self.pending_members = members
+        self.results = {}
+
+    def update(self, other):
+        self.pending_members.update(other.checked_members)
+        self.pending_members.update(other.pending_members)
+        self.pending_members -= self.checked_members
+
+    def __iter__(self):
+        return iter(self.checked_members | self.pending_members)
+
+    async def check(self):
+        maybe_changes = False
+
+        for inf in self.pending_members:
+            maybe_changes = True
+            for args, expected in self.results.items():
+                v = await inf(*args)
+                self.engine.equiv.declare_equivalent(expected, v)
+        self.checked_members.update(self.pending_members)
+        self.pending_members = set()
+
+        all_keys = set()
+        for m in self.checked_members:
+            all_keys.update(m.cache.keys())
+
+        to_check = all_keys - set(self.results.keys())
+
+        for args in to_check:
+            maybe_changes = True
+            inf1, *others = self.checked_members
+            res1 = inf1(*args)
+            self.results[args] = res1
+            for inf2 in others:
+                res2 = inf2(*args)
+                self.engine.equiv.declare_equivalent(res1, res2)
+
+        return maybe_changes
+
+
+class EquivalencePool:
+
+    def __init__(self, engine):
+        self.engine = engine
+        self.eqclasses = {}
+        self.pending = []
+        self.checked = {}
+
+    def declare_equivalent(self, x, y):
+        self.pending.append((x, y))
+        self.engine.schedule_function(self.check)
+
+    async def _process_equivalence(self, x, y):
+        vx = await x
+        vy = await y
+
+        if isinstance(vx, Inferrer) and isinstance(vy, Inferrer):
+            if vx.provably_equivalent(vy):
+                return
+
+            eqx = self.eqclasses.get(
+                vx, InferrerEquivalenceClass(self.engine, {vx})
+            )
+            eqy = self.eqclasses.get(
+                vy, InferrerEquivalenceClass(self.engine, {vy})
+            )
+            eqx.update(eqy)
+            for z in eqx:
+                self.eqclasses[z] = eqx
+
+        elif vx == vy:
+            pass
+
+        else:
+            self.engine.errors.add(
+                MyiaTypeError(f'Type mismatch: {vx} != {vy}')
+            )
+
+    async def check(self):
+        maybe_changes = False
+        pending, self.pending = self.pending, []
+        for x, y in pending:
+            await self._process_equivalence(x, y)
+            maybe_changes = True
+
+        for eq in set(self.eqclasses.values()):
+            maybe_changes |= await eq.check()
+
+        if maybe_changes:
+            self.engine.schedule_function(self.check)
+
+
+class EqEquivalence:
+    def __init__(self, engine):
+        self.engine = engine
+
+    def declare_equivalent(self, x, y):
+        self.engine.schedule(self.assert_equivalent(x, y))
+
+    async def assert_equivalent(self, x, y):
+        vx = await x
+        vy = await y
+        if not (vx == vy):
+            self.engine.errors.add(TypeError(f'Type mismatch: {vx} != {vy}'))
+
+
+class InferenceEngine:
+
+    def __init__(self, inferrers, eq_class=EquivalencePool):
+        self.loop = asyncio.get_event_loop()
+        self.tracks = tuple(inferrers.keys())
+        self.inferrers = inferrers
+        self.cache = {track: {} for track in self.tracks}
+        self.todo = set()
+        self.errors = set()
+        self.equiv = eq_class(self)
+
+    async def compute_ref(self, track, ref):
+        if isinstance(ref, VirtualReference):
+            return ref.values[track]
+        node = ref.node
+        ctx = ref.context
+        infs = self.inferrers[track]
+        if is_constant(node):
+            return await infs[Constant](self)(ref)
+        elif is_apply(node):
+            n_fn, *n_args = node.inputs
+            inf = await self.get(track, Reference(n_fn, ctx))
+            if inf is ANYTHING:
+                return ANYTHING
+            assert isinstance(inf, Inferrer)
+            argrefs = [Reference(node, ctx) for node in n_args]
+            return await inf(*argrefs)
+        else:
+            raise Exception(f'Cannot process: {node}')
+
+    def get(self, track, ref):
+        futs = self.cache[track]
+        if ref not in futs:
+            futs[ref] = self.loop.create_task(self.compute_ref(track, ref))
+        return futs[ref]
+
+    def cache_value(self, track, ref, value):
+        fut = asyncio.Future()
+        fut.set_result(value)
+        self.cache[track][ref] = fut
+
+    def schedule(self, coro):
+        self.todo.add(lambda: coro)
+
+    def schedule_function(self, fn):
+        self.todo.add(fn)
+
+    async def run(self, graph, args):
+        assert len(graph.parameters) == len(args)
+
+        ctx = Context(
+            self,
+            ((graph, track, tuple(arg[track] for arg in args))
+             for track in self.tracks)
+        )
+
+        for p, arg in zip(graph.parameters, args):
+            for track, value in arg.items():
+                ref = Reference(p, ctx)
+                self.cache_value(track, ref, value)
+
+        oref = Reference(graph.output, ctx)
+
+        for track in self.tracks:
+            self.schedule(self.get(track, oref))
+
+        while self.todo:
+            todo = list(self.todo)
+            self.todo = set()
+            todo = [t() for t in todo]
+            await asyncio.gather(*todo, loop=self.loop)
+
+        if self.errors:
+            raise self.errors.pop()
+        else:
+            return {track: self.cache[track][oref].result()
+                    for track in self.tracks}
+
+    def run_sync(self, graph, args):
+        self.deps = NestingAnalyzer(graph).graph_dependencies_total()
+        return self.loop.run_until_complete(self.run(graph, args))
+
+    async def force_same(self, track, *refs):
+        futs = [self.get(track, ref) if isinstance(ref, Reference) else ref
+                for ref in refs]
+        done, pending = await asyncio.wait(
+            futs,
+            loop=self.loop,
+            return_when=asyncio.FIRST_COMPLETED
+        )
+        main = done.pop()
+        for fut in done|pending:
+            self.equiv.declare_equivalent(fut, main)
+        return main.result()

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -63,15 +63,15 @@ type_inferrer = partial(register_inferrer,
 @type_inferrer(P.if_, nargs=3)
 async def infer_type_if(engine, cond, tb, fb):
     """Infer the return type of if."""
-    cond_t = await engine.get('type', cond)
+    cond_t = await cond['type']
     if cond_t != Bool():
         raise MyiaTypeError('Condition for if must be a boolean')
-    tb_inf = await engine.get('type', tb)
-    fb_inf = await engine.get('type', fb)
+    tb_inf = await tb['type']
+    fb_inf = await fb['type']
     if not isinstance(tb_inf, Inferrer) or not isinstance(fb_inf, Inferrer):
         raise MyiaTypeError('Both branches of if primitive must be thunks') \
             # pragma: no cover
-    v = await engine.get('value', cond)
+    v = await cond['value']
     if v is True:
         # We only visit the first branch if the condition is provably true
         return await tb_inf()
@@ -87,8 +87,8 @@ async def infer_type_if(engine, cond, tb, fb):
 @type_inferrer(P.cons_tuple, nargs=2)
 async def infer_type_cons_tuple(engine, x, y):
     """Infer the return type of cons_tuple."""
-    x_t = await engine.get('type', x)
-    y_t = await engine.get('type', y)
+    x_t = await x['type']
+    y_t = await y['type']
     if not isinstance(y_t, Tuple):
         raise MyiaTypeError('cons_tuple on non-tuple')  # pragma: no cover
     return Tuple([x_t, *y_t.elements])
@@ -97,7 +97,7 @@ async def infer_type_cons_tuple(engine, x, y):
 @type_inferrer(P.head, nargs=1)
 async def infer_type_head(engine, tup):
     """Infer the return type of head."""
-    tup_t = await engine.get('type', tup)
+    tup_t = await tup['type']
     if not isinstance(tup_t, Tuple):
         raise MyiaTypeError('head of non-tuple')
     if not len(tup_t.elements) >= 1:
@@ -108,7 +108,7 @@ async def infer_type_head(engine, tup):
 @type_inferrer(P.tail, nargs=1)
 async def infer_type_tail(engine, tup):
     """Infer the return type of tail."""
-    tup_t = await engine.get('type', tup)
+    tup_t = await tup['type']
     if not isinstance(tup_t, Tuple):
         raise MyiaTypeError('tail of non-tuple')
     if not len(tup_t.elements) >= 1:
@@ -119,13 +119,13 @@ async def infer_type_tail(engine, tup):
 @type_inferrer(P.getitem, nargs=2)
 async def infer_type_getitem(engine, seq, idx):
     """Infer the return type of getitem."""
-    seq_t = await engine.get('type', seq)
-    idx_t = await engine.get('type', idx)
+    seq_t = await seq['type']
+    idx_t = await idx['type']
     if not isinstance(idx_t, Int):
         raise MyiaTypeError('Expected Int for index')
 
     if isinstance(seq_t, Tuple):
-        idx_v = await engine.get('value', idx)
+        idx_v = await idx['value']
         if idx_v is ANYTHING:
             raise MyiaTypeError('Tuples must be indexed with a constant')
         return seq_t.elements[idx_v]
@@ -138,7 +138,7 @@ async def infer_type_getitem(engine, seq, idx):
 @type_inferrer(P.not_, nargs=1)
 async def infer_type_not(engine, x):
     """Infer the return type of not."""
-    x_t = await engine.get('type', x)
+    x_t = await x['type']
     if x_t != Bool():
         raise MyiaTypeError('Expected Bool for not.')
     return Bool()
@@ -163,7 +163,7 @@ async def infer_type_arith_compare(engine, x, y):
 @type_inferrer(P.uadd, P.usub, nargs=1)
 async def infer_type_arith_unary(engine, x):
     """Infer the return type of a unary arithmetic operator."""
-    t = await engine.get('type', x)
+    t = await x['type']
     if not isinstance(t, (Int, Float)):
         raise MyiaTypeError('Expected number')
     return t

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -58,7 +58,8 @@ async def infer_type_if(engine, cond, tb, fb):
     tb_inf = await engine.get('type', tb)
     fb_inf = await engine.get('type', fb)
     if not isinstance(tb_inf, Inferrer) or not isinstance(fb_inf, Inferrer):
-        raise MyiaTypeError('Both branches of if primitive must be thunks')
+        raise MyiaTypeError('Both branches of if primitive must be thunks') \
+            # pragma: no cover
     if v is True:
         return await tb_inf()
     elif v is False:
@@ -72,7 +73,7 @@ async def infer_type_cons_tuple(engine, x, y):
     x_t = await engine.get('type', x)
     y_t = await engine.get('type', y)
     if not isinstance(y_t, Tuple):
-        raise MyiaTypeError('cons_tuple on non-tuple')
+        raise MyiaTypeError('cons_tuple on non-tuple')  # pragma: no cover
     return Tuple([x_t, *y_t.elements])
 
 

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -1,0 +1,115 @@
+
+from ..dtype import Int, Bool, Float, Tuple, List
+from ..infer import ANYTHING, PrimitiveInferrer, GraphInferrer, \
+    MyiaTypeError
+from ..ir import Graph
+
+from . import ops as P
+from .ops import Primitive
+
+
+def typeof(v):
+    if isinstance(v, bool):
+        return Bool()
+    elif isinstance(v, int):
+        return Int(64)
+    elif isinstance(v, float):
+        return Float(64)
+    elif isinstance(v, tuple):
+        return Tuple(map(typeof, v))
+    else:
+        raise TypeError(f'Untypable value: {v}')
+
+
+class TypeTrack:
+
+    def __init__(self, constructors):
+        self.constructors = constructors
+
+    async def __call__(self, engine, ct):
+        v = ct.node.value
+        if isinstance(v, Primitive):
+            return self.constructors[v](engine)
+        elif isinstance(v, Graph):
+            return GraphInferrer(engine, 'type', v, ct.context)
+        else:
+            return typeof(ct.node.value)
+
+
+type_inferrer_constructors = {}
+infer_type_constant = TypeTrack(type_inferrer_constructors)
+
+
+def type_inferrer(prim):
+    def deco(fn):
+        def constructor(engine):
+            return PrimitiveInferrer(engine, 'type', fn)
+        type_inferrer_constructors[prim] = constructor
+        return fn
+    return deco
+
+
+@type_inferrer(P.if_)
+async def infer_type_if(engine, cond, tb, fb):
+    assert await engine.get('type', cond) == Bool()
+    v = await engine.get('value', cond)
+    tb_res = (await engine.get('type', tb))()
+    fb_res = (await engine.get('type', fb))()
+    if v is True:
+        return await tb_res
+    elif v is False:
+        return await fb_res
+    elif v is ANYTHING:
+        return await engine.force_same('type', tb_res, fb_res)
+
+
+@type_inferrer(P.cons_tuple)
+async def infer_type_cons_tuple(engine, x, y):
+    x_t = await engine.get('type', x)
+    y_t = await engine.get('type', y)
+    assert isinstance(y_t, Tuple)
+    return Tuple([x_t, *y_t.elements])
+
+
+@type_inferrer(P.getitem)
+async def infer_type_getitem(engine, seq, idx):
+    seq_t = await engine.get('type', seq)
+    idx_t = await engine.get('type', idx)
+    if not isinstance(idx_t, Int):
+        raise MyiaTypeError('Expected Int for index')
+
+    if isinstance(seq_t, Tuple):
+        idx_v = await engine.get('value', idx)
+        assert idx_v is not ANYTHING
+        return seq_t.elements[idx_v]
+    elif isinstance(seq_t, List):
+        return seq_t.element_type
+    else:
+        raise MyiaTypeError('Wrong seq type for getitem')
+
+
+async def infer_type_compare_bin(engine, x, y):
+    t = await engine.force_same('type', x, y)
+    if not isinstance(t, (Int, Float)):
+        raise MyiaTypeError('Expected number')
+    return Bool()
+
+
+async def infer_type_arith_bin(engine, x, y):
+    t = await engine.force_same('type', x, y)
+    if not isinstance(t, (Int, Float)):
+        raise MyiaTypeError('Expected number')
+    return t
+
+
+for op in [P.add, P.sub, P.mul]:
+    type_inferrer_constructors[op] = \
+        lambda engine: PrimitiveInferrer(
+            engine, 'type', infer_type_arith_bin
+        )
+
+for op in [P.lt, P.gt, P.eq, P.le, P.ge]:
+    type_inferrer_constructors[op] = \
+        lambda engine: PrimitiveInferrer(
+            engine, 'type', infer_type_compare_bin
+        )

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -43,7 +43,7 @@ infer_type_constant = TypeTrack(type_inferrer_constructors)
 def type_inferrer(prim):
     def deco(fn):
         def constructor(engine):
-            return PrimitiveInferrer(engine, 'type', prim, fn)
+            return PrimitiveInferrer(engine, prim, fn)
         type_inferrer_constructors[prim] = constructor
         return fn
     return deco
@@ -65,7 +65,7 @@ async def infer_type_if(engine, cond, tb, fb):
     elif v is False:
         return await fb_inf()
     elif v is ANYTHING:
-        return await engine.force_same('type', tb_inf(), fb_inf())
+        return await engine.assert_same('type', tb_inf(), fb_inf())
 
 
 @type_inferrer(P.cons_tuple)
@@ -116,7 +116,7 @@ async def infer_type_getitem(engine, seq, idx):
 
 
 async def infer_type_compare(engine, x, y):
-    t = await engine.force_same('type', x, y)
+    t = await engine.assert_same('type', x, y)
     if not isinstance(t, (Int, Float)):
         raise MyiaTypeError('Expected number')
     return Bool()
@@ -130,7 +130,7 @@ async def infer_type_arith_unary(engine, x):
 
 
 async def infer_type_arith_bin(engine, x, y):
-    t = await engine.force_same('type', x, y)
+    t = await engine.assert_same('type', x, y)
     if not isinstance(t, (Int, Float)):
         raise MyiaTypeError('Expected number')
     return t
@@ -138,7 +138,7 @@ async def infer_type_arith_bin(engine, x, y):
 
 def _register_inferrer(prim, fn):
     def construct(engine):
-        return PrimitiveInferrer(engine, 'type', prim, fn)
+        return PrimitiveInferrer(engine, prim, fn)
     type_inferrer_constructors[prim] = construct
 
 

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -43,7 +43,7 @@ infer_type_constant = TypeTrack(type_inferrer_constructors)
 def type_inferrer(prim):
     def deco(fn):
         def constructor(engine):
-            return PrimitiveInferrer(engine, 'type', fn)
+            return PrimitiveInferrer(engine, 'type', prim, fn)
         type_inferrer_constructors[prim] = constructor
         return fn
     return deco
@@ -137,7 +137,7 @@ async def infer_type_arith_bin(engine, x, y):
 
 def _register_inferrer(prim, fn):
     def construct(engine):
-        return PrimitiveInferrer(engine, 'type', fn)
+        return PrimitiveInferrer(engine, 'type', prim, fn)
     type_inferrer_constructors[prim] = construct
 
 

--- a/myia/prim/value_inferrers.py
+++ b/myia/prim/value_inferrers.py
@@ -48,16 +48,16 @@ value_inferrer_constructors = {}
 infer_value_constant = ValueTrack(pyimpl, value_inferrer_constructors)
 
 
-def value_inferrer(prim):
+def value_inferrer(prim, nargs):
     def deco(fn):
         def constructor(engine):
-            return PrimitiveInferrer(engine, prim, fn)
+            return PrimitiveInferrer(engine, prim, nargs, fn)
         value_inferrer_constructors[prim] = constructor
         return fn
     return deco
 
 
-@value_inferrer(P.if_)
+@value_inferrer(P.if_, 3)
 async def infer_value_if(engine, cond, tb, fb):
     v = await engine.get('value', cond)
     if v is True:

--- a/myia/prim/value_inferrers.py
+++ b/myia/prim/value_inferrers.py
@@ -51,7 +51,7 @@ infer_value_constant = ValueTrack(pyimpl, value_inferrer_constructors)
 def value_inferrer(prim):
     def deco(fn):
         def constructor(engine):
-            return PrimitiveInferrer(engine, 'value', prim, fn)
+            return PrimitiveInferrer(engine, prim, fn)
         value_inferrer_constructors[prim] = constructor
         return fn
     return deco

--- a/myia/prim/value_inferrers.py
+++ b/myia/prim/value_inferrers.py
@@ -1,0 +1,68 @@
+
+import asyncio
+
+from ..infer import ANYTHING, Inferrer, PrimitiveInferrer, GraphInferrer
+from ..ir import Graph
+
+from . import ops as P
+from .ops import Primitive
+from .py_implementations import implementations as pyimpl
+
+
+class PrimitiveValueInferrer(Inferrer):
+    def __init__(self, engine, impl):
+        super().__init__(engine)
+        self.impl = impl
+
+    async def infer(self, *refs):
+        coros = [self.engine.get('value', ref) for ref in refs]
+        args = await asyncio.gather(*coros, loop=self.engine.loop)
+        if any(arg is ANYTHING for arg in args):
+            return ANYTHING
+        else:
+            return self.impl(*args)
+
+
+class ValueTrack:
+
+    def __init__(self, implementations, constructors):
+        self.implementations = implementations
+        self.constructors = constructors
+
+    async def __call__(self, engine, ct):
+        v = ct.node.value
+        if isinstance(v, Primitive):
+            if v in self.constructors:
+                return self.constructors[v](engine)
+            else:
+                return PrimitiveValueInferrer(engine, self.implementations[v])
+        elif isinstance(v, Graph):
+            return GraphInferrer(engine, 'value', v, ct.context)
+        else:
+            return v
+
+
+value_inferrer_constructors = {}
+infer_value_constant = ValueTrack(pyimpl, value_inferrer_constructors)
+
+
+def value_inferrer(prim):
+    def deco(fn):
+        def constructor(engine):
+            return PrimitiveInferrer(engine, 'value', fn)
+        value_inferrer_constructors[prim] = constructor
+        return fn
+    return deco
+
+
+@value_inferrer(P.if_)
+async def infer_value_if(engine, cond, tb, fb):
+    v = await engine.get('value', cond)
+    if v is True:
+        fn = await engine.get('value', tb)
+    elif v is False:
+        fn = await engine.get('value', fb)
+    elif v is ANYTHING:
+        return ANYTHING
+
+    return await fn()

--- a/myia/prim/value_inferrers.py
+++ b/myia/prim/value_inferrers.py
@@ -27,7 +27,7 @@ class PrimitiveValueInferrer(Inferrer):
 
     async def infer(self, *refs):
         """Infer the return value of a function using its implementation."""
-        coros = [self.engine.get('value', ref) for ref in refs]
+        coros = [ref['value'] for ref in refs]
         args = await asyncio.gather(*coros, loop=self.engine.loop)
         if any(arg is ANYTHING for arg in args):
             return ANYTHING
@@ -84,11 +84,11 @@ async def infer_value_if(engine, cond, tb, fb):
     regardless of whether the value of either or both branches can
     be inferred.
     """
-    v = await engine.get('value', cond)
+    v = await cond['value']
     if v is True:
-        fn = await engine.get('value', tb)
+        fn = await tb['value']
     elif v is False:
-        fn = await engine.get('value', fb)
+        fn = await fb['value']
     elif v is ANYTHING:
         # Note: we do not infer the values for the branches at all.
         # If we did, we may encounter recursion and deadlock.

--- a/myia/prim/value_inferrers.py
+++ b/myia/prim/value_inferrers.py
@@ -5,12 +5,54 @@ import asyncio
 
 from functools import partial
 
-from ..infer import ANYTHING, Inferrer, GraphInferrer, register_inferrer
+from ..infer import \
+    ANYTHING, Inferrer, GraphInferrer, register_inferrer, Track
 from ..ir import Graph
 
 from . import ops as P
 from .ops import Primitive
 from .py_implementations import implementations as pyimpl
+
+
+class LimitedValue:
+    """Value associated to a count.
+
+    Attributes:
+        value: The value.
+        count: A count, which is intended to decrease to zero as we execute
+            functions and go down the stack, at which point we broaden the
+            value to ANYTHING.
+
+    """
+
+    @classmethod
+    def min_count(cls, lvs):
+        """Return the minimum count of all LimitedValues."""
+        return min(lv.count for lv in lvs)
+
+    def __init__(self, value, count):
+        """Initialize a LimitedValue."""
+        self.value = value
+        self.count = count
+
+    def __hash__(self):
+        return hash(self.value)
+
+    def __eq__(self, other):
+        return type(other) is LimitedValue \
+            and self.value == other.value
+
+    @property
+    def __unwrapped__(self):
+        return self.value
+
+
+def limited(v, count):
+    """Wrap the value if count > 0, else return ANYTHING."""
+    if count <= 0:
+        return ANYTHING
+    else:
+        return LimitedValue(v, count)
 
 
 class PrimitiveValueInferrer(Inferrer):
@@ -27,20 +69,28 @@ class PrimitiveValueInferrer(Inferrer):
 
     async def infer(self, *refs):
         """Infer the return value of a function using its implementation."""
-        coros = [ref['value'] for ref in refs]
+        coros = [self.engine.get_raw('value', ref) for ref in refs]
         args = await asyncio.gather(*coros, loop=self.engine.loop)
         if any(arg is ANYTHING for arg in args):
             return ANYTHING
         else:
-            return self.impl(*args)
+            args_unwrapped = [self.engine.unwrap(arg) for arg in args]
+            v = self.impl(*args_unwrapped)
+            n = LimitedValue.min_count(args)
+            return limited(v, n)
 
 
-class ValueTrack:
+value_inferrer_constructors = {}
+
+
+class ValueTrack(Track):
     """Infer the value of a constant.
 
     Note: the value of a Primitive or of a Graph is an Inferrer.
 
     Attributes:
+        max_depth: How deep in the call stack to infer values. Past that
+            depth, inferred values are degraded to ANYTHING.
         implementations: A map of primitives to implementations.
         constructors: A map of Inferrer constructors. Each constructor
             takes an engine as argument and returns an Inferrer. These
@@ -48,30 +98,62 @@ class ValueTrack:
 
     """
 
-    def __init__(self, implementations, constructors):
+    def __init__(self,
+                 engine,
+                 name,
+                 max_depth=10,
+                 implementations=pyimpl,
+                 constructors=value_inferrer_constructors):
         """Initialize a ValueTrack."""
+        super().__init__(engine, name)
         self.implementations = implementations
         self.constructors = constructors
+        self.max_depth = max_depth
 
-    async def __call__(self, engine, ct):
+    def wrap(self, v):
+        """Produce a LimitedValue for v, with a maximal count."""
+        return LimitedValue(v, self.max_depth)
+
+    def from_value(self, v, context):
         """Infer the value of a constant."""
-        v = ct.node.value
+        engine = self.engine
         if isinstance(v, Primitive):
             if v in self.constructors:
-                return self.constructors[v](engine)
+                inf = self.constructors[v](engine)
             else:
-                return PrimitiveValueInferrer(
+                inf = PrimitiveValueInferrer(
                     engine, v, self.implementations[v]
                 )
         elif isinstance(v, Graph):
-            return GraphInferrer(engine, 'value', v, ct.context)
+            inf = GraphInferrer(engine, 'value', v, context)
         else:
+            return self.wrap(v)
+
+        inf.__uninfer__ = v
+        return self.wrap(inf)
+
+    def fill_in(self, values, context=None):
+        """Fill in a value for this property, given others."""
+        if self.name in values:
+            v = values[self.name]
+            if v is not ANYTHING and not isinstance(v, LimitedValue):
+                values[self.name] = self.wrap(v)
+        else:
+            values[self.name] = ANYTHING
+
+    def broaden(self, v):
+        """Broaden the value if we reach a certain depth in the stack."""
+        if v is ANYTHING:
             return v
+        else:
+            return limited(v.value, v.count - 1)
 
 
-# Default constructors
-value_inferrer_constructors = {}
-infer_value_constant = ValueTrack(pyimpl, value_inferrer_constructors)
+########################
+# Default constructors #
+########################
+
+
 value_inferrer = partial(register_inferrer,
                          constructors=value_inferrer_constructors)
 

--- a/myia/prim/value_inferrers.py
+++ b/myia/prim/value_inferrers.py
@@ -3,7 +3,9 @@
 
 import asyncio
 
-from ..infer import ANYTHING, Inferrer, PrimitiveInferrer, GraphInferrer
+from functools import partial
+
+from ..infer import ANYTHING, Inferrer, GraphInferrer, register_inferrer
 from ..ir import Graph
 
 from . import ops as P
@@ -70,19 +72,11 @@ class ValueTrack:
 # Default constructors
 value_inferrer_constructors = {}
 infer_value_constant = ValueTrack(pyimpl, value_inferrer_constructors)
+value_inferrer = partial(register_inferrer,
+                         constructors=value_inferrer_constructors)
 
 
-def value_inferrer(prim, nargs):
-    """Define a value inferrer for prim with nargs arguments."""
-    def deco(fn):
-        def constructor(engine):
-            return PrimitiveInferrer(engine, prim, nargs, fn)
-        value_inferrer_constructors[prim] = constructor
-        return fn
-    return deco
-
-
-@value_inferrer(P.if_, 3)
+@value_inferrer(P.if_, nargs=3)
 async def infer_value_if(engine, cond, tb, fb):
     """Infer the return value of if.
 

--- a/myia/prim/value_inferrers.py
+++ b/myia/prim/value_inferrers.py
@@ -10,8 +10,8 @@ from .py_implementations import implementations as pyimpl
 
 
 class PrimitiveValueInferrer(Inferrer):
-    def __init__(self, engine, impl):
-        super().__init__(engine)
+    def __init__(self, engine, prim, impl):
+        super().__init__(engine, prim)
         self.impl = impl
 
     async def infer(self, *refs):
@@ -35,7 +35,9 @@ class ValueTrack:
             if v in self.constructors:
                 return self.constructors[v](engine)
             else:
-                return PrimitiveValueInferrer(engine, self.implementations[v])
+                return PrimitiveValueInferrer(
+                    engine, v, self.implementations[v]
+                )
         elif isinstance(v, Graph):
             return GraphInferrer(engine, 'value', v, ct.context)
         else:
@@ -49,7 +51,7 @@ infer_value_constant = ValueTrack(pyimpl, value_inferrer_constructors)
 def value_inferrer(prim):
     def deco(fn):
         def constructor(engine):
-            return PrimitiveInferrer(engine, 'value', fn)
+            return PrimitiveInferrer(engine, 'value', prim, fn)
         value_inferrer_constructors[prim] = constructor
         return fn
     return deco

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -418,7 +418,6 @@ def test_pow10(x):
     ]
 )
 def test_choose_prim(i, x, y):
-    add, mul
 
     def choose(i):
         if i == 0:
@@ -437,7 +436,6 @@ def test_choose_prim(i, x, y):
     ]
 )
 def test_choose_prim_incompatible(i, x, y):
-    add, lt
 
     def choose(i):
         if i == 0:
@@ -526,7 +524,6 @@ def test_hof(x):
     ]
 )
 def test_hof_2(c, x):
-    _to_i64
 
     def identity(x):
         return x

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -63,10 +63,10 @@ infer_value_constant = ValueTrack(pyimpl_test, value_inferrer_cons_test)
 infer_type_constant = TypeTrack(type_inferrer_cons_test)
 
 
-def primitive_inferrer(track, op, into):
+def primitive_inferrer(op, into):
     def deco(fn):
         def construct(engine):
-            return PrimitiveInferrer(engine, track, op, fn)
+            return PrimitiveInferrer(engine, op, fn)
         into[op] = construct
         return construct
 
@@ -85,7 +85,7 @@ def impl_map(f, xs):
 pyimpl_test[_map] = impl_map
 
 
-@primitive_inferrer('type', _map, into=type_inferrer_cons_test)
+@primitive_inferrer(_map, into=type_inferrer_cons_test)
 async def infer_type_map(engine, f, xs):
     f_t = await engine.get('type', f)
     xs_t = await engine.get('type', xs)
@@ -108,9 +108,9 @@ def impl_tern(x, y, z):
 pyimpl_test[_tern] = impl_tern
 
 
-@primitive_inferrer('type', _tern, into=type_inferrer_cons_test)
+@primitive_inferrer(_tern, into=type_inferrer_cons_test)
 async def infer_type_tern(engine, x, y, z):
-    ret_t = await engine.force_same('type', x, y, z)
+    ret_t = await engine.assert_same('type', x, y, z)
     assert isinstance(ret_t, (Int, Float))
     return ret_t
 
@@ -127,7 +127,7 @@ def impl_to_i64(x, y, z):
 pyimpl_test[_to_i64] = impl_to_i64
 
 
-@primitive_inferrer('type', _to_i64, into=type_inferrer_cons_test)
+@primitive_inferrer(_to_i64, into=type_inferrer_cons_test)
 async def infer_type_to_i64(engine, x):
     return Int(64)
 
@@ -163,7 +163,7 @@ def infer(**tests_spec):
                 timeout=0.1
             )
             try:
-                out = inferrer.run_sync(g, args)
+                out = inferrer.run(g, args)
             except MyiaTypeError as e:
                 out = TypeError
             assert out == expected_out

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -3,7 +3,8 @@ from pytest import mark
 
 from myia.api import parse
 from myia.infer import \
-    InferenceEngine, typeof, ANYTHING, all_inferrers, MyiaTypeError
+    InferenceEngine, typeof, ANYTHING, all_inferrers, MyiaTypeError, \
+    infer_value_constant, infer_type_constant
 
 from myia.dtype import Bool, Int, Float, Tuple as T, List as L
 from myia.prim.py_implementations import add, mul, lt
@@ -65,7 +66,10 @@ def infer(**tests_spec):
         def run_test(spec):
             *args, expected_out = spec
             g = parse(fn)
-            inferrer = InferenceEngine(all_inferrers)
+            inferrer = InferenceEngine({
+                'value': infer_value_constant,
+                'type': infer_type_constant,
+            })
             try:
                 out = inferrer.run_sync(g, args)
             except MyiaTypeError as e:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -150,7 +150,12 @@ def infer(**tests_spec):
     def decorate(fn):
         def run_test(spec):
             *args, expected_out = spec
+
             g = parse(fn)
+
+            print('Args:')
+            print(args)
+
             inferrer = InferenceEngine(
                 g, args,
                 constant_inferrers={
@@ -159,12 +164,28 @@ def infer(**tests_spec):
                 },
                 timeout=0.1
             )
-            try:
-                out = {track: inferrer.output_info(track)
-                       for track in all_tracks}
-            except MyiaTypeError as e:
-                out = TypeError
-            assert out == expected_out
+
+            def out():
+                rval = {track: inferrer.output_info(track)
+                        for track in all_tracks}
+                print('Output of inferrer:')
+                print(rval)
+                return rval
+
+            print('Expected:')
+            print(expected_out)
+
+            if expected_out is TypeError:
+                try:
+                    out()
+                except MyiaTypeError as e:
+                    pass
+                else:
+                    raise Exception(
+                        'Expected a TypeError, got: (see stdout).'
+                    )
+            else:
+                assert out() == expected_out
 
         m = mark.parametrize('spec', list(tests))(run_test)
         m.__orig__ = fn

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1,0 +1,429 @@
+
+from pytest import mark
+
+from myia.api import parse
+from myia.infer import \
+    InferenceEngine, typeof, ANYTHING, all_inferrers, MyiaTypeError
+
+from myia.dtype import Bool, Int, Float, Tuple as T, List as L
+from myia.prim.py_implementations import add, mul, lt
+
+
+B = Bool()
+
+i16 = Int(16)
+i32 = Int(32)
+i64 = Int(64)
+
+f16 = Float(16)
+f32 = Float(32)
+f64 = Float(64)
+
+li16 = L(Int(16))
+li32 = L(Int(32))
+li64 = L(Int(64))
+
+lf16 = L(Float(16))
+lf32 = L(Float(32))
+lf64 = L(Float(64))
+
+
+def fill_in(test, tracks):
+    for entry in test:
+        if entry is TypeError:
+            continue
+        for track in tracks:
+            if track in entry:
+                continue
+            elif track == 'type':
+                entry[track] = typeof(entry['value'])
+            elif track == 'value':
+                entry[track] = ANYTHING
+    return test
+
+
+def infer(**tests_spec):
+
+    tests = []
+    all_tracks = ['type', 'value']
+
+    for main_track, ts in tests_spec.items():
+        if not isinstance(ts, list):
+            ts = [ts]
+        for t in ts:
+            test = []
+            for entry in t:
+                if entry is TypeError:
+                    test.append(TypeError)
+                elif isinstance(entry, dict):
+                    test.append(entry)
+                else:
+                    test.append({main_track: entry})
+            tests.append(fill_in(test, all_tracks))
+
+    def decorate(fn):
+        def run_test(spec):
+            *args, expected_out = spec
+            g = parse(fn)
+            inferrer = InferenceEngine(all_inferrers)
+            try:
+                out = inferrer.run_sync(g, args)
+            except MyiaTypeError as e:
+                out = TypeError
+            assert out == expected_out
+
+        m = mark.parametrize('spec', list(tests))(run_test)
+        m.__orig__ = fn
+        return m
+
+    return decorate
+
+
+type_signature_arith_bin = [
+    (i64, i64, i64),
+    (f64, f64, f64),
+    (i64, f64, TypeError)
+]
+
+
+@infer(type=type_signature_arith_bin)
+def test_prim_mul(x, y):
+    return x * y
+
+
+@infer(type=type_signature_arith_bin)
+def test_if(x, y):
+    if x > y:
+        return x
+    else:
+        return y
+
+
+@infer(
+    type=[
+        (i64, i64, i64),
+        (i64, f64, f64),
+        (f64, f64, TypeError)
+    ]
+)
+def test_while(x, y):
+    rval = y
+    while x > 0:
+        rval = rval * y
+        x = x - 1
+    return rval
+
+
+@infer(type=(i64, f64, T(i64, f64)))
+def test_tup(x, y):
+    return (x, y)
+
+
+@infer(type=[(i64, f64, i64), (f64, i64, f64)])
+def test_getitem(x, y):
+    return (x, y)[0]
+
+
+@infer(type=(i64, f64, T(i64, f64)))
+def test_multitype_function(x, y):
+    def mul(a, b):
+        return a * b
+    return (mul(x, x), mul(y, y))
+
+
+@infer(type=type_signature_arith_bin)
+def test_closure(x, y):
+    def mul(a):
+        return a * x
+    return mul(x) + mul(y)
+
+
+@infer(
+    type=[
+        (i64, i64, i64, i64, T(i64, i64)),
+        (f64, f64, f64, f64, T(f64, f64)),
+        (i64, i64, f64, f64, T(i64, f64)),
+        (i64, f64, f64, f64, TypeError),
+        (i64, i64, i64, f64, TypeError),
+    ]
+)
+def test_return_closure(w, x, y, z):
+    def mul(a):
+        def clos(b):
+            return a * b
+        return clos
+    return (mul(w)(x), mul(y)(z))
+
+
+@infer(type=[(i64, i64), (f64, TypeError)])
+def test_fact(n):
+    def fact(n):
+        if n <= 1:
+            return 1
+        else:
+            return n * fact(n - 1)
+    return fact(n)
+
+
+def even(n):
+    if n == 0:
+        return True
+    else:
+        return odd(n - 1)
+
+
+def odd(n):
+    if n == 0:
+        return False
+    else:
+        return even(n - 1)
+
+
+@infer(type=[(i64, B), (f64, TypeError)])
+def test_even_odd(n):
+    return even(n)
+
+
+@infer(type=[(i64, i64), (f64, f64)])
+def test_pow10(x):
+    v = x
+    j = 0
+    while j < 3:
+        i = 0
+        while i < 3:
+            v = v * x
+            i = i + 1
+        j = j + 1
+    return v
+
+
+@infer(
+    type=[
+        (i64, i64, i64, i64),
+        (i64, f64, f64, f64)
+    ]
+)
+def test_choose_prim(i, x, y):
+    add, mul
+
+    def choose(i):
+        if i == 0:
+            return add
+        else:
+            return mul
+
+    return choose(i)(x, y)
+
+
+@infer(
+    type=[
+        (i64, i64, i64, TypeError),
+        ({'value': 0}, i64, i64, i64),
+        ({'value': 1}, i64, i64, B),
+    ]
+)
+def test_choose_prim_incompatible(i, x, y):
+    add, lt
+
+    def choose(i):
+        if i == 0:
+            return add
+        else:
+            return lt
+
+    return choose(i)(x, y)
+
+
+@infer(
+    type=[
+        (i64, i64, i64, TypeError),
+        ({'value': 0}, i64, i64, i64),
+        ({'value': 1}, i64, i64, B),
+    ]
+)
+def test_choose_incompatible(i, x, y):
+
+    def add2(x, y):
+        return x + y
+
+    def lt2(x, y):
+        return x < y
+
+    def choose(i):
+        if i == 0:
+            return add2
+        else:
+            return lt2
+
+    return choose(i)(x, y)
+
+
+@infer(
+    type=[
+        (i64, i64, i64),
+        (i64, f64, f64)
+    ]
+)
+def test_choose_indirect(i, x):
+
+    def double(x):
+        return x + x
+
+    def square(x):
+        return x * x
+
+    def choose(i):
+        if i == 0:
+            return double
+        else:
+            return square
+
+    return choose(i)(x)
+
+
+@infer(
+    type=[
+        (i64, i64)
+    ]
+)
+def test_hof(x):
+
+    def double(x):
+        return x + x
+
+    def square(x):
+        return x * x
+
+    def hof(f, tup):
+        return f(tup[0]) + f(tup[1])
+
+    return hof(double, (x + 1, x + 2)) + hof(square, (x + 3, x + 4))
+
+
+@infer(
+    type=[
+        (i64, T(T(i64, i64), T(B, B)))
+    ]
+)
+def test_hof_2(x):
+
+    def double(x):
+        return x + x
+
+    def is_zero(x):
+        return x == 0
+
+    def hof(f, tup):
+        return (f(tup[0]), f(tup[1]))
+
+    return (hof(double, (x + 1, x + 2)), hof(is_zero, (x + 3, x + 4)))
+
+
+@infer(
+    type=[
+        (i64, i64, TypeError),
+        ({'value': -1}, i64, i64),
+        ({'value': 1}, i64, T(i64, i64)),
+    ]
+)
+def test_hof_3(x, y):
+
+    def double(x):
+        return x + x
+
+    def hof_sum(f, tup):
+        return f(tup[0]) + f(tup[1])
+
+    def hof_tup(f, tup):
+        return (f(tup[0]), f(tup[1]))
+
+    def pick(x):
+        if x < 0:
+            return hof_sum
+        else:
+            return hof_tup
+
+    f = pick(x)
+    return f(double, (y + 3, y + 4))
+
+
+@infer(
+    type=[
+        (i64, i64, i64)
+    ]
+)
+def test_func_arg(x, y):
+     def g(func, x, y):
+         return func(x, y)
+
+     def h(x, y):
+         return x + y
+     return g(h, x, y)
+
+
+@infer(
+    type=[
+        (i64, TypeError)
+    ]
+)
+def test_func_arg3(x):
+    def g(func, x):
+        z = func + x
+        return func(z)
+
+    def h(x):
+        return x
+
+    return g(h, x)
+
+
+@infer(
+    type=[
+        (i64, i64),
+        (f64, f64),
+    ]
+)
+def test_func_arg4(x):
+    def h(x):
+        return x
+
+    def g(fn, x):
+        return fn(h, x)
+
+    def t(fn, x):
+        return fn(x)
+
+    return g(t, x)
+
+
+@infer(
+    type=[
+        ({'value': 4},),
+    ]
+)
+def test_closure_deep():
+    def g(x):
+        def h():
+            return x * x
+        return h
+    return g(2)()
+
+
+@infer(
+    type=[
+        (i64, i64, i64)
+    ],
+    value=[
+        (5, 7, 15)
+    ]
+)
+def test_closure_passing(x, y):
+    def adder(x):
+        def f(y):
+            return x + y
+        return f
+
+    a1 = adder(1)
+    a2 = adder(2)
+
+    return a1(x) + a2(y)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -152,14 +152,16 @@ def infer(**tests_spec):
             *args, expected_out = spec
             g = parse(fn)
             inferrer = InferenceEngine(
-                {
+                g, args,
+                constant_inferrers={
                     'value': infer_value_constant,
                     'type': infer_type_constant,
                 },
                 timeout=0.1
             )
             try:
-                out = inferrer.run(g, args)
+                out = {track: inferrer.output_info(track)
+                       for track in all_tracks}
             except MyiaTypeError as e:
                 out = TypeError
             assert out == expected_out

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -142,8 +142,14 @@ def infer(**tests_spec):
 type_signature_arith_bin = [
     (i64, i64, i64),
     (f64, f64, f64),
-    (i64, f64, TypeError)
+    (i64, f64, TypeError),
+    (B, B, TypeError),
 ]
+
+
+@infer(type=[({'value': 12.0, 'type': f64},)], value=[(12.0,)])
+def test_constants():
+    return 1.5 * 8.0
 
 
 @infer(type=type_signature_arith_bin)
@@ -151,8 +157,29 @@ def test_prim_mul(x, y):
     return x * y
 
 
+@infer(type=[(i64, i64), (f64, f64), (B, TypeError)])
+def test_prim_usub(x):
+    return -x
+
+
+@infer(
+    type=[
+        (B, f64, f64, f64),
+        (B, f64, i64, TypeError),
+        ({'value': True}, f64, i64, f64),
+        ({'value': False}, f64, i64, i64),
+        (i64, f64, f64, TypeError),
+    ]
+)
+def test_if(c, x, y):
+    if c:
+        return x * x
+    else:
+        return y * y
+
+
 @infer(type=type_signature_arith_bin)
-def test_if(x, y):
+def test_if2(x, y):
     if x > y:
         return x
     else:
@@ -179,15 +206,19 @@ def test_tup(x, y):
     return (x, y)
 
 
-@infer(type=[(i64, f64, i64), (f64, i64, f64)])
-def test_head_tuple(x, y):
-    tup = (x, y)
+@infer(type=[(T(i64, f64), i64),
+             (T(f64, i64), f64),
+             (T(), TypeError),
+             (f64, TypeError)])
+def test_head_tuple(tup):
     return head(tup)
 
 
-@infer(type=[(i64, f64, T(f64)), (f64, i64, T(i64))])
-def test_tail_tuple(x, y):
-    tup = (x, y)
+@infer(type=[(T(i64, f64), T(f64)),
+             (T(f64, i64), T(i64)),
+             (T(), TypeError),
+             (f64, TypeError)])
+def test_tail_tuple(tup):
     return tail(tup)
 
 


### PR DESCRIPTION
This implements type and value inference (shape inference can easily be added in the future) using a method based on `async` and `await`. This algorithm does not involve variables or unification. Here's what works:

* Type inference works through conditionals, loops, recursion.
* Type inference can rely on value inference and vice versa, so e.g. `getitem` on a tuple can infer the return type based on the value of the index.
* Graphs can be polymorphic (closures, too).
* Higher order primitives such as `map` can be typed, even if their argument is a graph or a closure.
* Higher order graphs can also be typed. The inferrer can deal with stuff like returning a different function depending on a condition (see `test_infer::test_hof_2`), although that may need to be tested a bit more extensively.

I think the algorithm is fairly solid, the only part that I trust a little less is the `InferrerEquivalenceClass` class that I use to determine whether two functions have the same type. It essentially collects every input type signature each function has seen, and checks that every function in the equivalence class has the same return type for each tuple of input types (keep in mind the relationship between input type and return type is an arbitrary function). It's powerful as hell, but I wouldn't be surprised if there was a bug or two.

I think this is probably already good enough, but there are some improvements left:

* The value inferrer currently infers everything it possibly can and there needs to be a way to prevent it from completely unrolling all loops when it knows the number of iterations. Basically a cap on the depth of the search tree.
* Some graphs can lead to deadlocked coroutines, which is currently solved using a very coarse timeout. I believe there are better ways to handle this. (Note: these graphs don't have valid types, I mean stuff like `def f(): return f()`)
* I want to add limited support for `isinstance`. This should allow graphs that dispatch on the type of their arguments. This shouldn't require any modifications to the inferrer itself. This will allow us to define e.g. `a + b` as the application of a graph that dispatches to lower-level primitives like `add_f32`, `add_i64`, etc. depending on input types.

After this, I plan on combining the results of the inferrer with existing optimization code in order to produce a type-specialized graph with the property that every node in every graph is associated to a single type. In a nutshell, a new graph would be built for every possible signature of a polymorphic graph. Then, at last, codegen should be a breeze.
