### PR TITLE
hastype and typeof

### DIFF
--- a/myia/dtype.py
+++ b/myia/dtype.py
@@ -110,6 +110,9 @@ class Type(metaclass=TypeMeta):
     def __eq__(self, other):
         return self is other
 
+    def __ne__(self, other):
+        return self is not other
+
     def __hash__(self):
         return id(self)
 

--- a/myia/dtype.py
+++ b/myia/dtype.py
@@ -39,6 +39,7 @@ class TypeMeta(type):
 
         if '__init__' not in ns:
             def init(self, *args):
+                assert len(args) == len(types)
                 for k, arg in zip(types.keys(), args):
                     setattr(self, k, arg)
 

--- a/myia/parser.py
+++ b/myia/parser.py
@@ -142,17 +142,15 @@ class Environment:
         """
         if id(obj) in self._object_map:
             return self._object_map[id(obj)]
-        elif isinstance(obj, (bool, float, int, str, primops.Primitive)):
-            node = Constant(obj)
-            self._object_map[id(obj)] = node
-            return node
         elif isinstance(obj, FunctionType):
             parser = Parser(self, obj)
             # This will insert object into the map
             parser.parse()
             return self._object_map[id(obj)]
         else:
-            raise ValueError(obj)
+            node = Constant(obj)
+            self._object_map[id(obj)] = node
+            return node
 
     def _remove(self, id: int) -> None:
         if id in self._object_map:

--- a/myia/prim/ops.py
+++ b/myia/prim/ops.py
@@ -43,6 +43,13 @@ ne = Primitive('ne')
 le = Primitive('le')
 ge = Primitive('ge')
 not_ = Primitive('not')
+
+
+######################
+# Type introspection #
+######################
+
+
 typeof = Primitive('typeof')
 hastype = Primitive('hastype')
 

--- a/myia/prim/ops.py
+++ b/myia/prim/ops.py
@@ -43,6 +43,8 @@ ne = Primitive('ne')
 le = Primitive('le')
 ge = Primitive('ge')
 not_ = Primitive('not')
+typeof = Primitive('typeof')
+hastype = Primitive('hastype')
 
 
 ###################

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -139,6 +139,12 @@ async def infer_type_getitem(engine, seq, idx):
         raise MyiaTypeError('Wrong seq type for getitem')
 
 
+@type_inferrer(P.typeof, nargs=1)
+async def infer_type_typeof(engine, _):
+    """Infer the return type of typeof."""
+    return Type
+
+
 @type_inferrer(P.hastype, nargs=2)
 async def infer_type_hastype(engine, x, t):
     """Infer the return type of hastype."""

--- a/myia/prim/value_inferrers.py
+++ b/myia/prim/value_inferrers.py
@@ -188,3 +188,9 @@ async def infer_value_hastype(engine, x, t):
     if t_v is ANYTHING:
         raise InferenceError('Second argument to hastype must be constant.')
     return hastype_helper(x_t, t_v)
+
+
+@value_inferrer(P.typeof, nargs=1)
+async def infer_value_typeof(engine, x):
+    """Infer the return value of typeof."""
+    return await x['type']

--- a/myia/prim/value_inferrers.py
+++ b/myia/prim/value_inferrers.py
@@ -5,13 +5,14 @@ import asyncio
 
 from functools import partial
 
-from ..infer import \
+from ..infer import InferenceError, \
     ANYTHING, Inferrer, GraphInferrer, register_inferrer, Track
 from ..ir import Graph
 
 from . import ops as P
 from .ops import Primitive
-from .py_implementations import implementations as pyimpl
+from .py_implementations import \
+    implementations as pyimpl, hastype_helper
 
 
 class LimitedValue:
@@ -177,3 +178,13 @@ async def infer_value_if(engine, cond, tb, fb):
         return ANYTHING
 
     return await fn()
+
+
+@value_inferrer(P.hastype, nargs=2)
+async def infer_value_hastype(engine, x, t):
+    """Infer the return value of hastype."""
+    x_t = await x['type']
+    t_v = await t['value']
+    if t_v is ANYTHING:
+        raise InferenceError('Second argument to hastype must be constant.')
+    return hastype_helper(x_t, t_v)

--- a/tests/prim/test_py_implementations.py
+++ b/tests/prim/test_py_implementations.py
@@ -1,7 +1,10 @@
+import pytest
+
 from types import SimpleNamespace
 
+from myia.dtype import Int, Float, List, Tuple
 from myia.prim.py_implementations import head, setattr as myia_setattr, \
-    setitem as myia_setitem, tail
+    setitem as myia_setitem, tail, hastype, typeof
 
 from ..test_lang import parse_compare
 
@@ -112,3 +115,32 @@ def test_prim_setattr():
     ns2 = SimpleNamespace(a=1, b=22)
     assert myia_setattr(ns, 'b', 22) == ns2
     assert ns != ns2  # test that this is not inplace
+
+
+def test_prim_typeof():
+    i64 = Int(64)
+    f64 = Float(64)
+    assert typeof(1) == i64
+    assert typeof(1.2) == f64
+    assert typeof((1, 2.0, (3, 4))) == Tuple(i64, f64, Tuple(i64, i64))
+    assert typeof([1, 2]) == List(i64)
+    with pytest.raises(TypeError):
+        typeof([1, 2, 3.4])
+    with pytest.raises(TypeError):
+        typeof(object())
+
+
+def test_prim_istype():
+    i64 = Int(64)
+    f64 = Float(64)
+    assert hastype(123, i64)
+    assert not hastype(123.4, i64)
+    assert hastype(123.4, f64)
+    assert hastype([1, 2, 3], List)
+    assert hastype([1, 2, 3], List(i64))
+    assert hastype((1, 2.0, (3, 4)), Tuple)
+    assert hastype((1, 2.0, (3, 4)), Tuple(i64, f64, Tuple(i64, i64)))
+    with pytest.raises(TypeError):
+        hastype([1, 2, 3.4], List)
+    with pytest.raises(TypeError):
+        hastype(object(), i64)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -11,7 +11,7 @@ from myia.dtype import Bool, Int, Float, Tuple as T, List as L, Type
 from myia.prim import Primitive
 from myia.prim.py_implementations import \
     implementations as pyimpl, \
-    add, mul, lt, head, tail, hastype
+    add, mul, lt, head, tail, hastype, typeof
 from myia.prim.value_inferrers import \
     ValueTrack, value_inferrer_constructors
 from myia.prim.type_inferrers import \
@@ -721,6 +721,15 @@ def test_hastype(x):
 )
 def test_bad_hastype(x, y):
     return hastype(x, y)
+
+
+@infer(
+    type=[(i64, Type)],
+    value=[({'type': i64}, i64),
+           ({'type': f64}, f64)]
+)
+def test_typeof(x):
+    return typeof(x)
 
 
 @infer(

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -7,11 +7,11 @@ from myia.infer import \
     InferenceEngine, ANYTHING, MyiaTypeError, InferenceError, \
     VirtualReference, register_inferrer
 
-from myia.dtype import Bool, Int, Float, Tuple as T, List as L
+from myia.dtype import Bool, Int, Float, Tuple as T, List as L, Type
 from myia.prim import Primitive
 from myia.prim.py_implementations import \
     implementations as pyimpl, \
-    add, mul, lt, head, tail
+    add, mul, lt, head, tail, hastype
 from myia.prim.value_inferrers import \
     ValueTrack, value_inferrer_constructors
 from myia.prim.type_inferrers import \
@@ -35,6 +35,8 @@ li64 = L(Int(64))
 lf16 = L(Float(16))
 lf32 = L(Float(32))
 lf64 = L(Float(64))
+
+Nil = T()
 
 
 ########################
@@ -702,6 +704,58 @@ def test_map(xs, ys):
         return x * x
 
     return _map(square, xs), _map(square, ys)
+
+
+@infer(
+    type=[(i64, B)],
+    value=[({'type': i64}, True),
+           ({'type': f64}, False)]
+)
+def test_hastype(x):
+    return hastype(x, i64)
+
+
+@infer(
+    type=(i64, i64, InferenceError),
+    value=(i64, {'type': Type, 'value': ANYTHING}, InferenceError),
+)
+def test_bad_hastype(x, y):
+    return hastype(x, y)
+
+
+@infer(
+    type=[
+        (i64, i64),
+        (f64, i64),
+        (T(i64, i64), i64),
+        (T(i64, T(f64, i64)), i64),
+        (li64, f64),
+        (T(i64, li64), InferenceError),
+    ],
+    value=[
+        (5, 5),
+        (6.0, 6),
+        ((5, 7, (3.2, 1.8)), 16)
+    ]
+)
+def test_hastype_2(x):
+    i64, f64, T, Nil, L, _to_i64, hastype, head, tail
+
+    def f(x):
+        if hastype(x, i64):
+            return x
+        elif hastype(x, f64):
+            return f(_to_i64(x))
+        elif hastype(x, Nil):
+            return 0
+        elif hastype(x, T):
+            return f(head(x)) + f(tail(x))
+        elif hastype(x, L):
+            return 1.0
+        else:
+            return 0
+
+    return f(x)
 
 
 @infer(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,15 +3,6 @@ import pytest
 from myia.api import parse
 
 
-def test_unsupported_object():
-    c = object()
-
-    def f():  # pragma: no cover
-        return c
-    with pytest.raises(ValueError):
-        parse(f)
-
-
 def test_undefined():
     def f():  # pragma: no cover
         return c  # noqa


### PR DESCRIPTION
This adds `hastype(obj, type)`, which can be used like `hastype(obj, Int(64))` or `hastype(obj, Tuple)`, and `typeof(obj)` which returns a `Type` object.

The value inferrer for `hastype` can consult the type inferrer in order to infer whether the condition is true or false, which will allow us to specialize functions that use this primitive. There are no inferrers for `typeof` at the moment.

I made some changes in `dtype` so that `Type` does not inherit from `tuple`.

The parser will now create a `Constant` for any global variable, regardless of what its type is. It will be the type inferrer's job to deal with that.
