### PR TITLE
Closure conversion

### DIFF
--- a/myia/cconv.py
+++ b/myia/cconv.py
@@ -1,0 +1,68 @@
+"""Closure conversion."""
+
+from collections import defaultdict
+
+from .info import About
+from .ir import Graph, Parameter, Constant, is_apply, is_constant_graph, manage
+from .prim import ops as P
+from .opt import sexp_to_node
+
+
+def closure_convert(root):
+    """Closure-convert all graphs starting from root.
+
+    The resulting graphs will have no free variables, but will instead get the
+    values of their free variables through additional arguments placed at the
+    beginning.
+
+    This is a destructive operation.
+    """
+    mng = manage(root)
+    fvs = {gg: list(g_fvs)
+           for gg, g_fvs in mng.free_variables_total.items()}
+
+    with mng.transact() as tr:
+        repl = defaultdict(dict)
+        for g in mng.graphs:
+            new_params = []
+            for node in fvs.get(g, []):
+                with About(node.debug, 'fv'):
+                    param = Parameter(g)
+                    new_params.append(param)
+                tr.set_parameters(g, new_params + g.parameters)
+                repl[g][node] = param
+
+        closures = [(g, g.parent) for g in mng.graphs if g.parent]
+
+        for g, parent in closures:
+            # This loop creates an incomplete partial() call and sets it in the
+            # repl directory immediately.
+            sexp = (P.partial, g)
+            repl[parent][g] = sexp_to_node(sexp, parent)
+
+        for g, parent in closures:
+            # This loop completes the partials. It's important to do this using
+            # two loops, because a closure's free variables may contain a
+            # different partial, so we want all of them to be available.
+            closure_args = []
+            for fv in fvs[g]:
+                if isinstance(fv, Graph):
+                    arg = repl[parent].get(fv, Constant(fv))
+                else:
+                    arg = repl[parent].get(fv, fv)
+                closure_args.append(arg)
+            repl[parent][g].inputs[2:] = closure_args
+
+        for g in mng.graphs:
+            rg = repl[g]
+            for node in g.nodes:
+                if is_apply(node):
+                    for i, inp in enumerate(node.inputs):
+                        if inp in rg:
+                            # node.inputs[i] = rg[inp]
+                            tr.set_edge(node, i, rg[inp])
+                        elif is_constant_graph(inp) and inp.value in rg:
+                            # node.inputs[i] = rg[inp.value]
+                            tr.set_edge(node, i, rg[inp.value])
+
+    return root

--- a/myia/debug/label.py
+++ b/myia/debug/label.py
@@ -12,6 +12,7 @@ short_relation_symbols = {
     'copy': '',
     'cosmetic': '',
     'phi': 'Φ',
+    'fv': '⤋',
     'if_true': '✓',
     'if_false': '✗',
     'if_after': '↓',

--- a/myia/prim/ops.py
+++ b/myia/prim/ops.py
@@ -97,3 +97,4 @@ return_ = Primitive('return')
 
 maplist = Primitive('maplist')
 resolve = Primitive('resolve')
+partial = Primitive('partial')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 import pytest
 
-from myia.api import compile
+from myia.api import parse, compile
+from myia.cconv import closure_convert
 from myia.prim.py_implementations import getitem
 
 
@@ -40,6 +41,20 @@ def test_return_closure():
         def g():
             return x + y
         return g
+
+    assert f(4, 5)() == 9
+
+
+def test_return_closure_partial():
+    """Return a closure (after closure conversion)."""
+    @parse
+    def f(x, y):
+        def g():
+            return x + y
+        return g
+
+    f = closure_convert(f)
+    f = compile(f)
 
     assert f(4, 5)() == 9
 

--- a/tests/test_cconv.py
+++ b/tests/test_cconv.py
@@ -1,0 +1,103 @@
+
+from pytest import mark
+
+from myia.api import parse, compile
+from myia.cconv import closure_convert
+from myia.ir import clone, manage
+
+
+def check_no_free_variables(root):
+    mng = manage(root)
+    for g, nodes in mng.nodes.items():
+        for node in nodes:
+            if node.graph is g:
+                continue
+            else:
+                raise Exception(f'Free variable detected: {node}')
+
+
+def cconv(*arglists):
+
+    def decorate(fn):
+        def run_test(args):
+            g = parse(fn)
+            result_py = fn(*args)
+            result_orig = compile(g)(*args)
+            assert result_py == result_orig
+            g2 = clone(g, total=True)
+            g2 = closure_convert(g2)
+            check_no_free_variables(g2)
+            result_final = compile(g2)(*args)
+            assert result_py == result_final
+
+        m = mark.parametrize('args', arglists)(run_test)
+        m.__orig__ = fn
+        return m
+
+    return decorate
+
+
+@cconv((12, 34))
+def test_straight(x, y):
+    return x * x + y * y
+
+
+@cconv((12,))
+def test_simple_closure(x):
+    def g():
+        return x
+
+    return g()
+
+
+@cconv((7, 3), (1, 3))
+def test_max(x, y):
+    if x > y:
+        return x
+    else:
+        return y
+
+
+@cconv((53,))
+def test_deep_nesting(x):
+    def f(y):
+        def g(z):
+            def h():
+                return y + z
+            return h
+        return g(x)
+    a = f(x + 1)
+    b = f(x - 3)
+    return a() + b()
+
+
+@cconv((10,))
+def test_return_in_double_while(x):
+    while x > 0:
+        while x > 0:
+            x = x - 1
+            return x
+    return -1  # pragma: no cover
+
+
+@cconv((3,))
+def test_pow10(x):
+    v = x
+    j = 0
+    while j < 3:
+        i = 0
+        while i < 3:
+            v = v * x
+            i = i + 1
+        j = j + 1
+    return v
+
+
+@cconv((53,))
+def test_closure_as_fv(x):
+    def f():
+        return x
+
+    def g():
+        return f()
+    return g()


### PR DESCRIPTION
This implements closure conversion on graphs. After the transform, no graphs have any free variables.

Currently, the transform adds free variables as extra arguments at the start of each function, and adds a `partial` primitive such that `partial(f, *args0)(*args1) <=> f(*args0, *args1)`. I added a special case in the VM to handle `partial` for testing purposes. Type inference through `partial` may not be necessary at the moment.

It would also be possible to pack free variables in a data structure and pass them in a single `env` argument, depending on what representation is more practical to deal with.
