### PR TITLE
Split py_implementations and vm_implementations

### DIFF
--- a/myia/api.py
+++ b/myia/api.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, List, Union
 
 from . import parser
 from .ir import ANFNode, Constant, Graph
-from .prim import implementations, ops as P
+from .prim import py_implementations, vm_implementations, ops as P
 from .vm import VM as VM_
 
 
@@ -32,14 +32,14 @@ def default_object_map() -> Dict[Any, ANFNode]:
         getattr: Constant(P.getattr),
         setattr: Constant(P.setattr)
     }
-    for prim, impl in implementations.items():
+    for prim, impl in py_implementations.items():
         mapping[impl] = Constant(prim)
 
     return mapping
 
 
 ENV = parser.Environment(default_object_map().items())
-VM = VM_(implementations)
+VM = VM_(vm_implementations, py_implementations)
 
 
 def parse(func: FunctionType) -> Graph:

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -6,7 +6,9 @@ from ..ir import replace, succ_incoming, freevars_boundary, \
     GraphCloner
 from ..unify import Var, var, SVar
 from ..prim import ops as P, Primitive
-from ..prim.py_implementations import implementations as pyimpl
+from ..prim.py_implementations import \
+    py_implementations as pyimpl, \
+    vm_implementations as vmimpl
 from ..cconv import NestingAnalyzer
 from ..vm import VM
 
@@ -187,17 +189,17 @@ simplify_always_false = psub(
 ########################
 
 
-def make_constant_prop(impl, vm_class=None):
+def make_constant_prop(vmimpl, pyimpl, vm_class=None):
     """Create a constant propagator that uses the given implementations."""
-    vm = vm_class and vm_class(impl)
+    vm = vm_class and vm_class(vmimpl, pyimpl)
 
     @pattern_replacer(C, Cs)
     def constant_prop(node, equiv):
         fn = equiv[C].value
         args = [ct.value for ct in equiv[Cs]]
         if isinstance(fn, Primitive):
-            if fn in impl:
-                return Constant(impl[fn](*args))
+            if fn in pyimpl:
+                return Constant(pyimpl[fn](*args))
             else:
                 return node
 
@@ -218,7 +220,7 @@ def make_constant_prop(impl, vm_class=None):
     return constant_prop
 
 
-constant_prop = make_constant_prop(pyimpl, VM)
+constant_prop = make_constant_prop(vmimpl, pyimpl, VM)
 
 
 ############

--- a/myia/prim/__init__.py
+++ b/myia/prim/__init__.py
@@ -1,4 +1,6 @@
 """Primitive operations."""
 
 from .ops import Primitive  # noqa
-from .py_implementations import implementations  # noqa
+from .py_implementations import (  # noqa
+    py_implementations, vm_implementations
+)

--- a/myia/prim/value_inferrers.py
+++ b/myia/prim/value_inferrers.py
@@ -12,7 +12,7 @@ from ..ir import Graph
 from . import ops as P
 from .ops import Primitive
 from .py_implementations import \
-    implementations as pyimpl, hastype_helper
+    py_implementations as pyimpl, hastype_helper
 
 
 class LimitedValue:

--- a/myia/vm.py
+++ b/myia/vm.py
@@ -82,10 +82,13 @@ class VM:
         def __init__(self, value):
             self.value = value
 
-    def __init__(self, implementations: Mapping[Primitive, Callable]) \
+    def __init__(self,
+                 implementations: Mapping[Primitive, Callable],
+                 py_implementations: Mapping[Primitive, Callable]) \
             -> None:
         """Initialize the VM."""
         self.implementations = implementations
+        self.py_implementations = py_implementations
 
     def convert_value(self, value):
         """Translate the value to a format that the VM understands."""
@@ -98,7 +101,7 @@ class VM:
     def unconvert_value(self, value):
         """Translate a VM-produced value to a user-faced format."""
         if isinstance(value, Primitive):
-            return self.implementations[value]
+            return self.py_implementations[value]
         elif isinstance(value, Closure):
             value.vm = self
             return value
@@ -208,7 +211,7 @@ class VM:
                 elif fn == return_:
                     raise self._Return(args[0])
                 else:
-                    frame.values[node] = self.implementations[fn](*args)
+                    frame.values[node] = self.implementations[fn](self, *args)
             else:
                 self._call(fn, args)
 

--- a/tests/opt/test_lib.py
+++ b/tests/opt/test_lib.py
@@ -5,7 +5,9 @@ from .test_opt import _check_opt
 from myia.opt import lib
 from myia.prim import ops
 from myia.prim.py_implementations import \
-    implementations as pyimpl, head, tail, setitem, add, mul
+    py_implementations as pyimpl, \
+    vm_implementations as vmimpl, \
+    head, tail, setitem, add, mul
 
 
 #######################
@@ -272,7 +274,7 @@ def test_ctprop_helper():
                lib.constant_prop)
 
     _check_opt(before, before,
-               lib.make_constant_prop(pyimpl, None))
+               lib.make_constant_prop(vmimpl, pyimpl, None))
 
 
 def test_ctprop_closure():
@@ -287,7 +289,7 @@ def test_ctprop_closure():
 
 
 def test_ctprop_subset():
-    prop = lib.make_constant_prop({
+    prop = lib.make_constant_prop(None, {
         ops.mul: lambda x, y: x * y
     })
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -9,7 +9,7 @@ from myia.infer import \
 from myia.dtype import Bool, Int, Float, Tuple as T, List as L, Type
 from myia.prim import Primitive
 from myia.prim.py_implementations import \
-    implementations as pyimpl, \
+    py_implementations as pyimpl, \
     add, mul, lt, head, tail, maplist, hastype, typeof, usub
 from myia.prim.value_inferrers import \
     ValueTrack, value_inferrer_constructors


### PR DESCRIPTION
Higher order primitives should have access to the vm as a parameter so that they can use it to run functions. The additional parameter is not used at the moment, but it will be once @abergeron commits a small modification to the vm.
