### PR TITLE
Pipeline

### DIFF
--- a/myia/api.py
+++ b/myia/api.py
@@ -5,6 +5,7 @@ from types import FunctionType
 from typing import Any, List
 
 from . import parser
+from .cconv import closure_convert
 from .infer import InferenceEngine
 from .ir import Graph, clone
 from .opt import PatternEquilibriumOptimizer, lib as optlib
@@ -207,6 +208,26 @@ class Specializer(PipelineStep):
         return {'graph': result}
 
 
+class ClosureConverter(PipelineStep):
+    """Pipeline step to closure convert a graph.
+
+    Inputs:
+        graph: The graph to closure convert.
+
+    Outputs:
+        graph: The closure converted graph.
+    """
+
+    def __init__(self, pipeline_init):
+        """Initialize a ClosureConverter."""
+        super().__init__(pipeline_init)
+
+    def step(self, graph):
+        """Closure convert the graph."""
+        closure_convert(graph)
+        return {'graph': graph}
+
+
 class Exporter(PipelineStep):
     """Pipeline step to export a callable.
 
@@ -263,6 +284,7 @@ standard_pipeline = PipelineDefinition(
                 optlib.inline_unique_uses,
             ]
         ),
+        cconv=ClosureConverter.partial(),
         export=Exporter.partial(
             implementations=vm_implementations
         )

--- a/myia/api.py
+++ b/myia/api.py
@@ -197,10 +197,6 @@ class Specializer(PipelineStep):
         graph: The specialized graph.
     """
 
-    def __init__(self, pipeline_init):
-        """Initialize a Specializer."""
-        super().__init__(pipeline_init)
-
     def step(self, graph, inferrer):
         """Specialize the graph according to argument types."""
         spc = TypeSpecializer(inferrer)
@@ -217,10 +213,6 @@ class ClosureConverter(PipelineStep):
     Outputs:
         graph: The closure converted graph.
     """
-
-    def __init__(self, pipeline_init):
-        """Initialize a ClosureConverter."""
-        super().__init__(pipeline_init)
 
     def step(self, graph):
         """Closure convert the graph."""

--- a/myia/api.py
+++ b/myia/api.py
@@ -2,60 +2,43 @@
 
 import operator
 from types import FunctionType
-from typing import Any, Dict, List
+from typing import Any, List
 
 from . import parser
-from .ir import ANFNode, Graph, clone
+from .infer import InferenceEngine
+from .ir import Graph, clone
 from .opt import PatternEquilibriumOptimizer, lib as optlib
+from .pipeline import PipelineStep, PipelineDefinition
 from .prim import py_implementations, vm_implementations, ops as P
+from .prim.value_inferrers import ValueTrack, value_inferrer_constructors
+from .prim.type_inferrers import TypeTrack, type_inferrer_constructors
+from .prim.shape_inferrers import ShapeTrack, shape_inferrer_constructors
+from .specialize import TypeSpecializer
 from .utils import TypeMap
 from .vm import VM
 
 
-def default_object_map() -> Dict[Any, ANFNode]:
-    """Get a mapping from Python objects to nodes."""
-    mapping = {
-        operator.add: P.add,
-        operator.sub: P.sub,
-        operator.mul: P.mul,
-        operator.truediv: P.div,
-        operator.mod: P.mod,
-        operator.pow: P.pow,
-        operator.eq: P.eq,
-        operator.ne: P.ne,
-        operator.lt: P.lt,
-        operator.gt: P.gt,
-        operator.le: P.le,
-        operator.ge: P.ge,
-        operator.pos: P.uadd,
-        operator.neg: P.usub,
-        operator.not_: P.not_,
-        operator.getitem: P.getitem,
-        operator.setitem: P.setitem,
-        getattr: P.getattr,
-        setattr: P.setattr,
-    }
-    for prim, impl in py_implementations.items():
-        mapping[impl] = prim
-    return mapping
-
-
-class Converter:
-    """Convert a Python object into an object that can be in a Myia graph."""
-
-    def __init__(self, object_map, converters):
-        """Initialize a Converter."""
-        self.object_map = object_map
-        self.converters = converters
-
-    def __call__(self, value):
-        """Convert a value."""
-        try:
-            return self.object_map[value]
-        except (TypeError, KeyError):
-            pass
-
-        return self.converters[type(value)](self, value)
+default_object_map = {
+    operator.add: P.add,
+    operator.sub: P.sub,
+    operator.mul: P.mul,
+    operator.truediv: P.div,
+    operator.mod: P.mod,
+    operator.pow: P.pow,
+    operator.eq: P.eq,
+    operator.ne: P.ne,
+    operator.lt: P.lt,
+    operator.gt: P.gt,
+    operator.le: P.le,
+    operator.ge: P.ge,
+    operator.pos: P.uadd,
+    operator.neg: P.usub,
+    operator.not_: P.not_,
+    operator.getitem: P.getitem,
+    operator.setitem: P.setitem,
+    getattr: P.getattr,
+    setattr: P.setattr,
+}
 
 
 def _convert_identity(env, x):
@@ -72,44 +55,216 @@ def _convert_function(env, fn):
     return g
 
 
-def lax_converter():
-    """Return a "lax" converter that allows arbitrary objects."""
-    return Converter(
-        default_object_map(),
-        TypeMap({
-            FunctionType: _convert_function,
-            tuple: _convert_sequence,
-            list: _convert_sequence,
-            object: _convert_identity,
-            type: _convert_identity,
-        })
-    )
-
-
-default_vm = VM(vm_implementations,
-                py_implementations,
-                lax_converter())
+lax_type_map = TypeMap({
+    FunctionType: _convert_function,
+    tuple: _convert_sequence,
+    list: _convert_sequence,
+    object: _convert_identity,
+    type: _convert_identity,
+})
 
 
 def parse(func: FunctionType, resolve_globals=True) -> Graph:
     """Parse a function into ANF."""
-    converter = lax_converter()
-    resolver_opt = PatternEquilibriumOptimizer(
-        optlib.make_resolver(converter)
-    )
-    g = converter(func)
-    if resolve_globals:
-        resolver_opt(g)
-        g = clone(g)
+    pdef = standard_pipeline.select('parse', 'resolve')
+    pdef = pdef.configure(resolve=resolve_globals)
+    g = pdef.make()(input=func)['graph']
     return g
 
 
 def run(g: Graph, args: List[Any]) -> Any:
     """Evaluate a graph on a set of arguments."""
-    return default_vm.evaluate(g, args)
+    pdef = standard_pipeline.select('export')
+    f = pdef.make()(graph=g)['output']
+    return f(*args)
 
 
 def compile(obj):
     """Return a version of the function that runs using Myia's VM."""
-    myia_obj = default_vm.convert(obj)
-    return default_vm.export(myia_obj)
+    pdef = standard_pipeline.select(
+        'parse', 'resolve', 'export'
+    )
+    return pdef.make()(input=obj)['output']
+
+
+############
+# Pipeline #
+############
+
+
+class Converter(PipelineStep):
+    """Convert a Python object into an object that can be in a Myia graph."""
+
+    def __init__(self, pipeline_init, object_map, converters):
+        """Initialize a Converter."""
+        super().__init__(pipeline_init)
+        self.object_map = dict(object_map)
+        for prim, impl in self.resources.py_implementations.items():
+            self.object_map[impl] = prim
+        self.converters = converters
+
+    def __call__(self, value):
+        """Convert a value."""
+        try:
+            return self.object_map[value]
+        except (TypeError, KeyError):
+            pass
+
+        return self.converters[type(value)](self, value)
+
+
+class Parser(PipelineStep):
+    """Pipeline step to parse a function.
+
+    Inputs:
+        input: A function.
+
+    Outputs:
+        graph: A graph.
+    """
+
+    def step(self, input):
+        """Assert that input is a Graph, and set it as the 'graph' key."""
+        g = self.resources.convert(input)
+        assert isinstance(g, Graph)
+        return {'graph': g}
+
+
+class Optimizer(PipelineStep):
+    """Pipeline step to optimize a graph.
+
+    Inputs:
+        graph: The graph to optimize.
+
+    Outputs:
+        graph: The optimized graph.
+    """
+
+    def __init__(self, pipeline_init, opts):
+        """Initialize an Optimizer."""
+        super().__init__(pipeline_init)
+        self.opts = opts
+
+    def step(self, graph):
+        """Optimize the graph using the given patterns."""
+        eq = PatternEquilibriumOptimizer(*self.opts, optimizer=self)
+        eq(graph)
+        return {'graph': graph}
+
+
+class Inferrer(PipelineStep):
+    """Pipeline step to run type/shape/value/etc. inference.
+
+    Inputs:
+        graph: The graph to infer.
+        argspec: Information about argument types.
+
+    Outputs:
+        inference_results: Inference results for the graph's output.
+        inferrer: The inference engine.
+    """
+
+    def __init__(self, pipeline_init, tracks, required_tracks, timeout):
+        """Initialize an Inferrer."""
+        super().__init__(pipeline_init)
+        self.tracks = tracks
+        self.required_tracks = required_tracks
+        self.timeout = timeout
+
+    def step(self, graph, argspec):
+        """Infer types, shapes, values, etc. for the graph."""
+        argprops = argspec
+        engine = InferenceEngine(
+            self.pipeline,
+            graph, argprops,
+            tracks=self.tracks,
+            required_tracks=self.required_tracks,
+            timeout=self.timeout
+        )
+        return {'inference_results': engine.output_info(),
+                'inferrer': engine}
+
+
+class Specializer(PipelineStep):
+    """Pipeline step to specialize a graph.
+
+    Inputs:
+        graph: The graph to specialize.
+        inferrer: The inference engine.
+
+    Outputs:
+        graph: The specialized graph.
+    """
+
+    def __init__(self, pipeline_init):
+        """Initialize a Specializer."""
+        super().__init__(pipeline_init)
+
+    def step(self, graph, inferrer):
+        """Specialize the graph according to argument types."""
+        spc = TypeSpecializer(inferrer)
+        result = spc.result
+        return {'graph': result}
+
+
+class Exporter(PipelineStep):
+    """Pipeline step to export a callable.
+
+    Inputs:
+        graph: The graph to wrap into a callable.
+
+    Outputs:
+        output: The callable.
+    """
+
+    def __init__(self, pipeline_init, implementations):
+        """Initialize an Exporter."""
+        super().__init__(pipeline_init)
+        self.vm = VM(self.pipeline, implementations)
+
+    def step(self, graph):
+        """Make a Python callable out of the graph."""
+        return {'output': self.vm.export(graph)}
+
+
+standard_pipeline = PipelineDefinition(
+    resources=dict(
+        py_implementations=py_implementations,
+        convert=Converter.partial(
+            object_map=default_object_map,
+            converters=lax_type_map
+        )
+    ),
+    steps=dict(
+        parse=Parser.partial(),
+        resolve=Optimizer.partial(
+            opts=[optlib.resolve_globals]
+        ),
+        infer=Inferrer.partial(
+            tracks=dict(
+                value=ValueTrack.partial(
+                    constructors=value_inferrer_constructors
+                ),
+                type=TypeTrack.partial(
+                    constructors=type_inferrer_constructors
+                ),
+                shape=ShapeTrack.partial(
+                    constructors=shape_inferrer_constructors
+                )
+            ),
+            required_tracks=['type'],
+            timeout=1
+        ),
+        specialize=Specializer.partial(),
+        opt=Optimizer.partial(
+            opts=[
+                optlib.simplify_always_true,
+                optlib.simplify_always_false,
+                optlib.inline_unique_uses,
+            ]
+        ),
+        export=Exporter.partial(
+            implementations=vm_implementations
+        )
+    )
+)

--- a/myia/api.py
+++ b/myia/api.py
@@ -9,7 +9,7 @@ from .cconv import closure_convert
 from .infer import InferenceEngine
 from .ir import Graph, clone
 from .opt import PatternEquilibriumOptimizer, lib as optlib
-from .pipeline import PipelineStep, PipelineDefinition
+from .pipeline import PipelineStep, PipelineResource, PipelineDefinition
 from .prim import py_implementations, vm_implementations, ops as P
 from .prim.value_inferrers import ValueTrack, value_inferrer_constructors
 from .prim.type_inferrers import TypeTrack, type_inferrer_constructors
@@ -93,7 +93,7 @@ def compile(obj):
 ############
 
 
-class Converter(PipelineStep):
+class Converter(PipelineResource):
     """Convert a Python object into an object that can be in a Myia graph."""
 
     def __init__(self, pipeline_init, object_map, converters):
@@ -220,7 +220,7 @@ class ClosureConverter(PipelineStep):
         return {'graph': graph}
 
 
-class Exporter(PipelineStep):
+class DebugVMExporter(PipelineStep):
     """Pipeline step to export a callable.
 
     Inputs:
@@ -231,7 +231,7 @@ class Exporter(PipelineStep):
     """
 
     def __init__(self, pipeline_init, implementations):
-        """Initialize an Exporter."""
+        """Initialize an DebugVMExporter."""
         super().__init__(pipeline_init)
         self.vm = VM(self.pipeline, implementations)
 
@@ -280,7 +280,7 @@ step_opt = Optimizer.partial(
 step_cconv = ClosureConverter.partial()
 
 
-step_export = Exporter.partial(
+step_export = DebugVMExporter.partial(
     implementations=vm_implementations
 )
 

--- a/myia/infer.py
+++ b/myia/infer.py
@@ -3,6 +3,7 @@
 import asyncio
 
 from .ir import is_constant, is_constant_graph, is_apply, manage
+from .pipeline import Partializable
 from .utils import Named
 
 
@@ -39,7 +40,7 @@ def type_error_nargs(ident, expected, got):
 #########
 
 
-class Track:
+class Track(Partializable):
     """Represents a property to infer."""
 
     def __init__(self, engine, name):
@@ -515,6 +516,7 @@ class InferenceEngine:
     """
 
     def __init__(self,
+                 pipeline,
                  graph,
                  argvals,
                  *,
@@ -523,11 +525,13 @@ class InferenceEngine:
                  eq_class=EquivalencePool,
                  timeout=1.0):
         """Initialize the InferenceEngine."""
+        self.pipeline = pipeline
+
         self.graph = graph
 
         self.all_track_names = tuple(tracks.keys())
         self.tracks = {
-            name: t(self, name)
+            name: t(engine=self, name=name)
             for name, t in tracks.items()
         }
         self.required_tracks = required_tracks or self.all_track_names
@@ -629,13 +633,14 @@ class InferenceEngine:
         v = self.get_raw(track, ref).result()
         return self.unwrap(v)
 
-    def output_info(self, track):
+    def output_info(self):
         """Return information about the output of the analyzed graph."""
         if self.errors:
             raise self.errors[0]['error']
         else:
             oref = self.ref(self.graph.return_, self.root_context)
-            return self.get_info(track, oref)
+            return {track: self.get_info(track, oref)
+                    for track in self.required_tracks}
 
     def cache_value(self, track, ref, value):
         """Set the value of the Reference on the given track."""
@@ -743,7 +748,3 @@ class InferenceEngine:
             for task in asyncio.Task.all_tasks(self.loop):
                 task._log_destroy_pending = False
         return res
-
-    def close(self):
-        """Close this inferrer's loop."""
-        self.loop.close()

--- a/myia/infer.py
+++ b/myia/infer.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from .ir import is_constant, is_constant_graph, is_apply, manage
+from .ir import is_constant, is_constant_graph, is_apply
 from .pipeline import Partializable
 from .utils import Named
 
@@ -545,7 +545,8 @@ class InferenceEngine:
         self.errors = []
         self.equiv = eq_class(self)
 
-        self.mng = manage(graph)
+        self.mng = self.pipeline.resources.manager
+        self.mng.add_graph(graph)
         empty_context = Context.empty()
         self.root_context = empty_context.add(graph, argvals)
 

--- a/myia/ir/manager.py
+++ b/myia/ir/manager.py
@@ -4,6 +4,7 @@
 from collections import defaultdict, Counter
 
 from ..graph_utils import dfs, FOLLOW, EXCLUDE
+from ..pipeline import Partializable
 from ..utils import Events
 
 from .utils import succ_deeper, is_constant, is_constant_graph, is_parameter
@@ -425,7 +426,7 @@ class RecursiveStatistic(NestingStatistic):
             self[g] = g in gs
 
 
-class GraphManager:
+class GraphManager(Partializable):
     """Structure to hold information about graphs and modify them.
 
     Attributes are updated incrementally when graph mutations are committed.

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -186,20 +186,13 @@ simplify_always_false = psub(
 ###################
 
 
-def make_resolver(convert):
-    """Create an optimization to resolve globals.
-
-    Args:
-        convert: The function to use for conversion.
-    """
-    @pattern_replacer(P.resolve, CNS, C)
-    def resolve_globals(optimizer, node, equiv):
-        ns = equiv[CNS]
-        x = equiv[C]
-        g = convert(ns.value[x.value])
-        return Constant(g)
-
-    return resolve_globals
+@pattern_replacer(P.resolve, CNS, C)
+def resolve_globals(optimizer, node, equiv):
+    """Resolve global variables."""
+    ns = equiv[CNS]
+    x = equiv[C]
+    res = optimizer.resources.convert(ns.value[x.value])
+    return Constant(res)
 
 
 ############

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -50,7 +50,7 @@ def primset_var(*prims):
 
 
 @pattern_replacer(P.getitem, (P.cons_tuple, X, Y), C)
-def getitem_tuple(node, equiv):
+def getitem_tuple(optimizer, node, equiv):
     """Match a constant index in an explicit tuple.
 
     (a, b, c, ...)[0] => a
@@ -66,7 +66,7 @@ def getitem_tuple(node, equiv):
 
 
 @pattern_replacer(P.setitem, (P.cons_tuple, X, Y), C, Z)
-def setitem_tuple(node, equiv):
+def setitem_tuple(optimizer, node, equiv):
     """Match a constant setitem in an explicit tuple.
 
     setitem((a, b, c, ...), 0, z) => (z, b, c, ...)
@@ -193,7 +193,7 @@ def make_resolver(convert):
         convert: The function to use for conversion.
     """
     @pattern_replacer(P.resolve, CNS, C)
-    def resolve_globals(node, equiv):
+    def resolve_globals(optimizer, node, equiv):
         ns = equiv[CNS]
         x = equiv[C]
         g = convert(ns.value[x.value])
@@ -217,7 +217,7 @@ def make_inliner(inline_criterion, check_recursive):
             before inlining it. If it is, don't inline.
     """
     @pattern_replacer(G, Xs)
-    def inline(node, equiv):
+    def inline(optimizer, node, equiv):
         g = equiv[G].value
         args = equiv[Xs]
 
@@ -278,7 +278,7 @@ inline = make_inliner(inline_criterion=None, check_recursive=True)
 
 
 @pattern_replacer((G, Xs), Ys)
-def drop_into_call(node, equiv):
+def drop_into_call(optimizer, node, equiv):
     """Drop a call into the graph that returns the function.
 
     g(x)(y) => g2(x, y)
@@ -300,7 +300,7 @@ def drop_into_call(node, equiv):
 
 
 @pattern_replacer((P.if_, X, Y, Z), Xs)
-def drop_into_if(node, equiv):
+def drop_into_if(optimizer, node, equiv):
     """Drop a call on the result of if into both branches.
 
     f(if(x, y, z)) => if(x, () -> f(y()), () -> f(z()))

--- a/myia/opt/opt.py
+++ b/myia/opt/opt.py
@@ -137,12 +137,18 @@ class PatternEquilibriumOptimizer:
 
     def __call__(self, *graphs):
         """Apply optimizations until equilibrium on given graphs."""
-        mng = manage(*graphs)
+        if self.optimizer is not None:
+            mng = self.optimizer.resources.manager
+            for g in graphs:
+                mng.add_graph(g)
+        else:
+            mng = manage(*graphs)
+
         while True:
             changes = False
 
             with mng.transact() as tr:
-                for node in mng.all_nodes:
+                for node in list(mng.all_nodes):
                     for transformer in self.node_transformers:
                         new = transformer(self.optimizer, node)
                         if new and new is not node:

--- a/myia/opt/opt.py
+++ b/myia/opt/opt.py
@@ -97,7 +97,7 @@ class PatternSubstitutionOptimization:
         self.unif = Unification()
         self.name = name
 
-    def __call__(self, node):
+    def __call__(self, optimizer, node):
         """Return a replacement for the node, if the pattern matches.
 
         The replacement will be instantiated in the graph of the root of the
@@ -113,7 +113,7 @@ class PatternSubstitutionOptimization:
         equiv = self.unif.unify(node, self.pattern)
         if equiv:
             if callable(self.replacement):
-                return self.replacement(node, equiv)
+                return self.replacement(optimizer, node, equiv)
             else:
                 return self.unif.reify(self.replacement, equiv)
         else:
@@ -130,9 +130,10 @@ def pattern_replacer(*pattern):
 class PatternEquilibriumOptimizer:
     """Apply a set of local pattern optimizations until equilibrium."""
 
-    def __init__(self, *node_transformers):
+    def __init__(self, *node_transformers, optimizer=None):
         """Initialize a PatternEquilibriumOptimizer."""
         self.node_transformers = node_transformers
+        self.optimizer = optimizer
 
     def __call__(self, *graphs):
         """Apply optimizations until equilibrium on given graphs."""
@@ -143,7 +144,7 @@ class PatternEquilibriumOptimizer:
             with mng.transact() as tr:
                 for node in mng.all_nodes:
                     for transformer in self.node_transformers:
-                        new = transformer(node)
+                        new = transformer(self.optimizer, node)
                         if new and new is not node:
                             new.type = node.type
                             tr.replace(node, new)

--- a/myia/pipeline.py
+++ b/myia/pipeline.py
@@ -1,0 +1,511 @@
+"""Tools to generate and configure Myia's operation pipeline."""
+
+
+import inspect
+from myia.utils import TypeMap
+from myia.utils import Named
+
+
+# Use in a merge to indicate that a key should be deleted
+DELETE = Named('DELETE')
+
+
+# Placeholder for MergeMode.__init__
+_ABSENT = Named('_ABSENT')
+
+
+class MergeMode:
+    """Wraps a value to control how it is merged.
+
+    Class attributes:
+        mode: The merge mode to use.
+
+    Attributes:
+        value: The value to merge.
+
+    """
+
+    mode = 'merge'  # NOTE: This is the default merge mode used by merge()
+
+    def __init__(self, __value=_ABSENT, **kwargs):
+        """Initialize a MergeMode.
+
+        The value to merge will be the single argument given, or if there is no
+        positional argument, the keywords dictionary.
+        """
+        if __value is _ABSENT:
+            self.value = kwargs
+        else:
+            assert not kwargs
+            self.value = __value
+
+
+class Merge(MergeMode):
+    """Merge normally."""
+
+    mode = 'merge'
+
+
+class Override(MergeMode):
+    """Do not concatenate sequences."""
+
+    mode = 'override'
+
+
+class Reset(MergeMode):
+    """Throw away the previous value."""
+
+    mode = 'reset'
+
+
+_cleanup_map = TypeMap()
+
+
+@_cleanup_map.register(object)
+def _cleanup_object(value):
+    return value
+
+
+@_cleanup_map.register(MergeMode)
+def _cleanup_MergeMode(mm):
+    return mm.value
+
+
+@_cleanup_map.register(dict)
+def _cleanup_dict(d):
+    return type(d)({k: cleanup(v) for k, v in d.items() if v is not DELETE})
+
+
+def _cleanup_sequence(xs):
+    return type(xs)(cleanup(x) for x in xs)
+
+
+_cleanup_map.register(tuple, _cleanup_sequence)
+_cleanup_map.register(list, _cleanup_sequence)
+_cleanup_map.register(set, _cleanup_sequence)
+
+
+def cleanup(x):
+    """Remove all MergeMode and DELETE instances from the data."""
+    return _cleanup_map[type(x)](x)
+
+
+_merge_map = TypeMap(discover=lambda cls: getattr(cls, '__merge__', None))
+
+
+@_merge_map.register(dict)
+def _merge_dict(d1, d2, mode):
+    if mode == 'reset':
+        return type(d1)(d2)
+
+    rval = type(d1)()
+    for k, v in d1.items():
+        if k in d2:
+            v2 = d2[k]
+            if v2 is DELETE:
+                pass
+            else:
+                rval[k] = merge(v, v2, mode)
+        else:
+            rval[k] = v
+    for k, v in d2.items():
+        if k not in d1:
+            rval[k] = cleanup(v)
+    return rval
+
+
+@_merge_map.register(tuple)
+def _merge_tuple(xs, ys, mode):
+    xs = cleanup(xs)
+    ys = cleanup(ys)
+    if mode == 'merge':
+        return xs + ys
+    else:
+        return ys
+
+
+@_merge_map.register(list)
+def _merge_list(xs, ys, mode):
+    xs = cleanup(xs)
+    ys = cleanup(ys)
+    if mode == 'merge':
+        return xs + ys
+    else:
+        return ys
+
+
+@_merge_map.register(set)
+def _merge_set(xs, ys, mode):
+    xs = cleanup(xs)
+    ys = cleanup(ys)
+    if mode == 'merge':
+        return xs | ys
+    else:
+        return ys
+
+
+@_merge_map.register(object)
+def _merge_object(a, b, mode):
+    return cleanup(b)
+
+
+def merge(a, b, mode=MergeMode.mode):
+    """Merge two data structures.
+
+    Arguments:
+        a: The original data.
+        b: The data to merge.
+        mode:
+            'merge': (default) Sequences will be concatenated, sets merged,
+                and dictionaries merged according to their keys.
+            'override': Dictionaries are merged, but sequences are not
+                concatenated.
+            'reset': b is returned, or takes primacy over the data in a.
+    """
+    if isinstance(b, MergeMode):
+        mode = b.mode
+        b = b.value
+    assert not isinstance(a, MergeMode)
+    return _merge_map[type(a)](a, b, mode)
+
+
+class NS:
+    """Namespace for pipeline stages.
+
+    This namespace preserves key order in the representation, unlike
+    types.SimpleNamespace.
+    """
+
+    def __init__(self, **kwargs):
+        """Initialize NS."""
+        self.__dict__.update(kwargs)
+
+    # def __getitem__(self, item):
+    #     return self.__dict__[item]
+
+    def __setitem__(self, item, value):
+        self.__dict__[item] = value
+
+    def __repr__(self):
+        args = [f'{k}={v}' for k, v in self.__dict__.items()]
+        return f'NS({", ".join(args)})'
+
+
+class Partial:
+    """Partial application of a function.
+
+    This differs from functools.partial in a few ways:
+
+    * Only keyword arguments are accepted.
+    * Argument names are validated immediately.
+    * It is possible to merge two partials, with the second updating the
+      parameters of the first. It is also possible to merge a dict and
+      a Partial. Merge and Override work basically like on dictionaries.
+    * `merge(partial1, Override(partial2))` lets us change the
+      constructor.
+    """
+
+    def __init__(self, func, *,
+                 _wrap=False,
+                 **keywords):
+        """Initialize a Partial."""
+        self.wrap = _wrap
+        self.func = func
+        self.keywords = keywords
+        self._validate()
+
+    def _validate(self):
+        """Check that all the argument names are valid."""
+        if isinstance(self.func, type):
+            f = getattr(self.func, '__init__', self.func)
+        else:
+            f = self.func
+        spec = inspect.getfullargspec(f)
+        if spec.varkw:
+            return
+        valid = spec.args + spec.kwonlyargs
+        for k, v in self.keywords.items():
+            if k not in valid:
+                raise TypeError(f"{f} has no argument named '{k}'")
+
+    def __call__(self, **kwargs):
+        """Run the pipeline on the given arguments, from start to finish."""
+        value = self.func(**self.keywords, **kwargs)
+        if self.wrap:
+            value = self.wrap(value)
+        return value
+
+    def __merge__(self, partial, mode):
+        """Combine arguments from two partials."""
+        if isinstance(partial, dict):
+            partial = Partial(self.func, **partial)
+
+        assert isinstance(partial, Partial)
+
+        if partial.func is self.func \
+                or mode == 'override' or mode == 'reset':
+            func = partial.func
+        else:
+            raise ValueError('Incompatible func')
+
+        if mode == 'reset':
+            kwargs = partial.keywords
+        elif mode == 'override':
+            kwargs = {**self.keywords, **partial.keywords}
+        else:
+            kwargs = merge(self.keywords, partial.keywords)
+
+        wrap = partial.wrap or self.wrap
+        return Partial(func, _wrap=wrap, **kwargs)
+
+    def __repr__(self):
+        args = [f'{k}={v}' for k, v in self.keywords.items()]
+        return f'{self.func.__name__}({", ".join(args)})'
+
+
+class Partializable:
+    """Class for which partial instances may be created.
+
+    This defines `Class.partial(arg=val, ...)`, which is equivalent to
+    `Partial(Class, arg=val, ...)`.
+    """
+
+    @classmethod
+    def partial(cls, **kwargs):
+        """Return a Partial on this class constructor."""
+        return Partial(cls, **kwargs)
+
+
+class PipelineDefinition:
+    """Defines a Pipeline.
+
+    A PipelineDefinition can be configured in a fine-grained manner.
+    Call `make()` to instantiate a Pipeline that can be executed.
+
+    Attributes:
+        resources: An ensemble of common resources, pooled by the whole
+            pipeline.
+        steps: A sequence of steps. Each step should be a Partial on a
+            PipelineStep.
+
+    """
+
+    def __init__(self, *, resources=None, steps):
+        """Initialize a PipelineDefinition."""
+        self.resources = resources or {}
+        self.steps = list(steps.items())
+        self.step_names = list(steps.keys())
+
+    def index(self, step, upper_bound=False):
+        """Return the index corresponding to the given step.
+
+        Args:
+            step: The name of the step, or an int (returned without
+                modification).
+            upper_bound: Whether this is meant to be used as an
+                upper bound or not. If it is True, then:
+                * 1 will be added to the result if the step is a
+                  string, so that it becomes inclusive,
+                * unless it starts with !
+                * Integers are still returned without modification.
+        """
+        if isinstance(step, str):
+            if step.startswith('!'):
+                return self.step_names.index(step[1:])
+            else:
+                plus = 1 if upper_bound else 0
+                return self.step_names.index(step) + plus
+        elif isinstance(step, int) or step is None:
+            return step
+        else:  # pragma: no cover
+            raise TypeError('index should be a string or int')
+
+    def getslice(self, item):
+        """Transform an item or a string slice into a numeric slice.
+
+        The index for a string corresponds to a step name.
+
+        >>> pd = PipelineDefinition(steps=dict(a=..., b=..., c=...))
+        >>> pd.getslice("b")
+        slice(1, 2)
+        >>> pd.getslice(slice("b", "c"))
+        slice(1, 3)
+        """
+        if isinstance(item, slice):
+            assert item.step is None
+            return slice(self.index(item.start),
+                         self.index(item.stop, True))
+        else:
+            return slice(0, self.index(item, True))
+
+    def insert_before(self, step=0, **new_steps):
+        """Insert new steps before the given step.
+
+        If no step is given, the new steps are inserted at the very beginning.
+
+        This returns a new PipelineDefinition.
+        """
+        steps = list(self.steps)
+        index = self.index(step) or 0
+        steps[index:index] = new_steps.items()
+        return PipelineDefinition(
+            resources=self.resources,
+            steps=dict(steps)
+        )
+
+    def insert_after(self, step=None, **new_steps):
+        """Insert new steps after the given step.
+
+        If no step is given, the new steps are inserted at the very end.
+
+        This returns a new PipelineDefinition.
+        """
+        steps = list(self.steps)
+        if step is None:
+            steps.extend(new_steps.items())
+        else:
+            index = self.index(step)
+            steps[index + 1:index + 1] = new_steps.items()
+        return PipelineDefinition(
+            resources=self.resources,
+            steps=dict(steps)
+        )
+
+    def configure_resources(self, **resources):
+        """Change resources or define new resources.
+
+        This returns a new PipelineDefinition.
+        """
+        return PipelineDefinition(
+            resources=merge(self.resources, resources),
+            steps=dict(self.steps)
+        )
+
+    def configure(self, changes={}, **kwchanges):
+        """Configure existing resources and steps.
+
+        To add new steps, use `insert_before` or `insert_after`. To add new
+        resources, use `configure_resources`.
+
+        This returns a new PipelineDefinition.
+
+        By default, new data is merged. These are all equivalent:
+
+        >>> pd.configure(mystep={'param': 234})
+        >>> pd.configure(mystep=Merge(param=234))
+        >>> pd.configure({'mystep.param': 234})
+
+        `mystep` will keep all of its previous parameters, except for the
+        overriden one. If the parameter is a list, the list given in the
+        update will be appended to the previous, but you can use
+        `Override([a, b, c])` to replace the old list.
+        """
+        def activator(active):
+            def wrap(x):
+                x.active = active
+                return x
+            return wrap
+        new_data = {**dict(self.steps), **self.resources}
+        changes = {**changes, **kwchanges}
+        for path, delta in changes.items():
+            if isinstance(delta, bool) and path in self.step_names:
+                delta = dict(_wrap=activator(delta))
+            top, *parts = path.split('.')
+            for part in reversed(parts):
+                delta = {part: delta}
+            new_data[top] = merge(new_data[top], delta)
+        return PipelineDefinition(
+            resources={k: new_data[k] for k in self.resources},
+            steps={k: new_data[k] for k in self.step_names}
+        )
+
+    def make(self):
+        """Create a Pipeline from this definition."""
+        return Pipeline(self)
+
+    def __getitem__(self, item):
+        """Return a pipeline that only contains a subset of the steps."""
+        return PipelineDefinition(
+            resources=self.resources,
+            steps=dict(self.steps[self.getslice(item)])
+        )
+
+
+class Pipeline:
+    """Sequence of connected processing steps.
+
+    Created from a PipelineDefinition. Each step processes the output of the
+    previous step. A Pipeline also defines common resources for all the steps.
+    """
+
+    def __init__(self, defn):
+        """Initialize a Pipeline from a PipelineDefinition."""
+        def convert(x, name):
+            if isinstance(x, Partial):
+                x = x()
+            if hasattr(x, 'set_pipeline'):
+                x.set_pipeline(pipeline=self, name=name)
+            return x
+
+        self.defn = defn
+        self.resources = NS()
+        self.steps = NS()
+        self._seq = []
+        for k, v in defn.resources.items():
+            self.resources[k] = convert(v, None)
+        for k, v in defn.steps:
+            v = convert(v, k)
+            self.steps[k] = v
+            self._seq.append(v)
+
+    def __getitem__(self, item):
+        """Return a sub-pipeline.
+
+        item may be the name of a step, in which case the resulting
+        sub-pipeline goes from the beginning to that step (inclusive), or it
+        may be a range that starts at a given step and ends at another
+        (again, inclusive).
+        """
+        return _PipelineSlice(self, item)
+
+    def __call__(self, **args):
+        """Execute the pipeline from start to finish."""
+        return self[:](**args)
+
+
+class _PipelineSlice:
+    def __init__(self, pipeline, slice):
+        self.pipeline = pipeline
+        self.slice = self.pipeline.defn.getslice(slice)
+
+    def __call__(self, **args):
+        for step in self.pipeline._seq[self.slice]:
+            if step.active:
+                args = step.step(**args)
+        return args
+
+
+class PipelineStep(Partializable):
+    """Step in a Pipeline."""
+
+    def __init__(self):
+        """Initialize a PipelineStep."""
+        self.active = True
+
+    def set_pipeline(self, pipeline, name):
+        """Set the pipeline field to this step's parent pipeline."""
+        self.pipeline = pipeline
+        self.name = name
+        self.steps = pipeline.steps
+        self.resources = pipeline.resources
+
+    def step(self, **kwargs):
+        """Execute this step only.
+
+        The received arguments come from the previous step.
+        """
+        raise NotImplementedError()
+
+    def __call__(self, **args):
+        """Execute the pipeline all the way up to this step."""
+        return self.pipeline[:self.name](**args)

--- a/myia/pipeline.py
+++ b/myia/pipeline.py
@@ -429,6 +429,10 @@ class PipelineDefinition:
         """Create a Pipeline from this definition."""
         return Pipeline(self)
 
+    def run(self, **args):
+        """Run a Pipeline made from this definition."""
+        return self.make()(**args)
+
     def __getitem__(self, item):
         """Return a pipeline that only contains a subset of the steps."""
         steps = list(self.steps.items())

--- a/myia/pipeline.py
+++ b/myia/pipeline.py
@@ -191,8 +191,8 @@ class NS:
         """Initialize NS."""
         self.__dict__.update(kwargs)
 
-    # def __getitem__(self, item):
-    #     return self.__dict__[item]
+    def __getitem__(self, item):
+        return self.__dict__[item]
 
     def __setitem__(self, item, value):
         self.__dict__[item] = value

--- a/myia/pipeline.py
+++ b/myia/pipeline.py
@@ -453,7 +453,12 @@ class Pipeline:
         """Initialize a Pipeline from a PipelineDefinition."""
         def convert(x, name):
             if isinstance(x, Partial):
-                x = x.partial(pipeline_init={'pipeline': self, 'name': name})
+                try:
+                    x = x.partial(
+                        pipeline_init={'pipeline': self, 'name': name}
+                    )
+                except TypeError:
+                    pass
                 x = x()
             return x
 

--- a/myia/pipeline.py
+++ b/myia/pipeline.py
@@ -238,9 +238,8 @@ class Partial:
         return merge(self, keywords)
 
     def __call__(self, **kwargs):
-        """Run the pipeline on the given arguments, from start to finish."""
-        value = self.func(**self.keywords, **kwargs)
-        return value
+        """Merge stored arguments with kwargs and call the function."""
+        return self.func(**self.keywords, **kwargs)
 
     def __merge__(self, partial, mode):
         """Combine arguments from two partials."""
@@ -318,7 +317,7 @@ class PipelineDefinition:
                 return self.step_names.index(step) + plus
         elif isinstance(step, int) or step is None:
             return step
-        else:  # pragma: no cover
+        else:
             raise TypeError('index should be a string or int')
 
     def getslice(self, item):
@@ -493,8 +492,8 @@ class _PipelineSlice:
         return args
 
 
-class PipelineStep(Partializable):
-    """Step in a Pipeline."""
+class PipelineResource(Partializable):
+    """Resource in a Pipeline."""
 
     def __init__(self, pipeline_init):
         """Initialize a PipelineStep."""
@@ -503,6 +502,10 @@ class PipelineStep(Partializable):
         self.pipeline = pipeline_init['pipeline']
         self.steps = self.pipeline.steps
         self.resources = self.pipeline.resources
+
+
+class PipelineStep(PipelineResource):
+    """Step in a Pipeline."""
 
     def step(self, **kwargs):
         """Execute this step only.

--- a/myia/prim/value_inferrers.py
+++ b/myia/prim/value_inferrers.py
@@ -11,8 +11,7 @@ from ..ir import Graph
 
 from . import ops as P
 from .ops import Primitive
-from .py_implementations import \
-    py_implementations as pyimpl, hastype_helper
+from .py_implementations import hastype_helper
 
 
 class LimitedValue:
@@ -103,11 +102,10 @@ class ValueTrack(Track):
                  engine,
                  name,
                  max_depth=10,
-                 implementations=pyimpl,
                  constructors=value_inferrer_constructors):
         """Initialize a ValueTrack."""
         super().__init__(engine, name)
-        self.implementations = implementations
+        self.implementations = engine.pipeline.resources.py_implementations
         self.constructors = constructors
         self.max_depth = max_depth
 

--- a/myia/vm.py
+++ b/myia/vm.py
@@ -6,7 +6,7 @@ implementation.
 """
 
 from collections import defaultdict
-from typing import Iterable, Mapping, Any, Callable, List
+from typing import Iterable, Mapping, Any, List
 
 from .ir import Graph, Apply, Constant, Parameter, ANFNode, manage
 from .ir.utils import is_constant_graph, is_constant
@@ -96,12 +96,9 @@ class VM:
         def __init__(self, value):
             self.value = value
 
-    def __init__(self,
-                 implementations: Mapping[Primitive, Callable],
-                 py_implementations: Mapping[Primitive, Callable],
-                 convert) -> None:
+    def __init__(self, pipeline, implementations):
         """Initialize the VM."""
-        self.convert = convert
+        self.convert = pipeline.resources.convert
         self._exporters = TypeMap({
             tuple: self._export_sequence,
             list: self._export_sequence,
@@ -111,7 +108,7 @@ class VM:
             object: self._export_object,
         })
         self.implementations = implementations
-        self.py_implementations = py_implementations
+        self.py_implementations = pipeline.resources.py_implementations
         self._vars = defaultdict(set)
 
     def _compute_fvs(self, graph):

--- a/myia/vm.py
+++ b/myia/vm.py
@@ -8,7 +8,7 @@ implementation.
 from collections import defaultdict
 from typing import Iterable, Mapping, Any, List
 
-from .ir import Graph, Apply, Constant, Parameter, ANFNode, manage
+from .ir import Graph, Apply, Constant, Parameter, ANFNode
 from .ir.utils import is_constant_graph, is_constant
 from .prim import Primitive
 from .prim.ops import if_, return_, partial
@@ -99,6 +99,7 @@ class VM:
     def __init__(self, pipeline, implementations):
         """Initialize the VM."""
         self.convert = pipeline.resources.convert
+        self.manager = pipeline.resources.manager
         self._exporters = TypeMap({
             tuple: self._export_sequence,
             list: self._export_sequence,
@@ -123,7 +124,7 @@ class VM:
     def _acquire_graph(self, graph):
         if graph in self._vars:
             return
-        manage(graph)
+        self.manager.add_graph(graph)
         for g in graph.manager.graphs:
             self._vars[g] = self._compute_fvs(g)
 

--- a/tests/ir/test_clone.py
+++ b/tests/ir/test_clone.py
@@ -223,6 +223,7 @@ def test_clone_unused_parameters():
 
 
 def test_clone_without_forcing_manager():
+    @clone
     @parse
     def f(x, y):
         return x * y

--- a/tests/opt/test_opt.py
+++ b/tests/opt/test_opt.py
@@ -249,7 +249,7 @@ def test_fn_replacement():
         return x
 
     @pattern_replacer(Q, X)
-    def elim_QPs(node, equiv):
+    def elim_QPs(optimizer, node, equiv):
         # Q(P(...P(x))) => x
         arg = equiv[X]
         while arg.inputs and arg.inputs[0].value == P:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@ import pytest
 
 from myia.api import parse, compile
 from myia.cconv import closure_convert
+from myia.ir import clone
 from myia.prim.py_implementations import getitem
 
 
@@ -53,10 +54,11 @@ def test_return_closure_partial():
             return x + y
         return g
 
-    f = closure_convert(f)
+    f = clone(closure_convert(f))
     f = compile(f)
 
-    assert f(4, 5)() == 9
+    g = f(4, 5)
+    assert g() == 9
 
 
 def test_return_closure_tuple():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -237,7 +237,7 @@ def test_Pipeline(op_pipeline):
     assert pip['!square'](value=3) == {'value': -8}
     assert pip['mulp':'!neg'](value=3) == {'value': 6}
 
-    assert pdef['mulp':'neg'].make()(value=3) == {'value': -6}
+    assert pdef['mulp':'neg'].run(value=3) == {'value': -6}
 
 
 def test_Pipeline_configure(op_pipeline):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,268 @@
+
+import pytest
+from myia.pipeline import merge, Partial, PipelineStep, \
+    PipelineDefinition, Merge, Reset, Override, DELETE, cleanup
+from myia.utils import TypeMap
+
+
+class OpStep(PipelineStep):
+
+    def __init__(self, op, param=0):
+        super().__init__()
+        self.op = op
+        self.param = param
+
+    def step(self, value):
+        return {'value': self.op(self.param, value)}
+
+
+class OpResourceStep(PipelineStep):
+
+    def __init__(self, op):
+        super().__init__()
+        self.op = op
+
+    def step(self, value):
+        return {'value': self.op(self.resources.param, value)}
+
+
+@pytest.fixture
+def op_pipeline():
+    return PipelineDefinition(
+        resources=dict(
+            param=2
+        ),
+        steps=dict(
+            addp=OpStep.partial(op=lambda p, x: p + x, param=1),
+            mulp=OpResourceStep.partial(op=lambda p, x: p * x),
+            neg=OpStep.partial(op=lambda p, x: -x),
+            square=OpStep.partial(op=lambda p, x: x * x),
+        )
+    )
+
+
+def test_merge():
+
+    assert merge(1, 2) == 2
+    assert merge([1, 2], [3, 4]) == [1, 2, 3, 4]
+    assert merge((1, 2), (3, 4)) == (1, 2, 3, 4)
+    assert merge({1, 2}, {3, 4}) == {1, 2, 3, 4}
+
+    a = dict(a=1, b=2, c=dict(d=3, e=[4, 5]))
+    b = dict(a=1, b=2, c=dict(e=[6, 7], f=8))
+    c = dict(a=1, b=2, c=dict(d=3, e=[4, 5, 6, 7], f=8))
+
+    assert merge(a, b) == c
+
+    dlt = dict(c=DELETE, d=3)
+    assert merge(a, dlt) == dict(a=1, b=2, d=3)
+
+
+def test_merge_subclass():
+
+    tm = TypeMap({int: "int"})
+    mtm = merge(tm, {str: "str"})
+    assert isinstance(mtm, TypeMap)
+    assert mtm == TypeMap({int: "int", str: "str"})
+
+
+def test_merge_modes():
+
+    for x, y in [({1, 2}, {3, 4}),
+                 ([1, 2], [3, 4]),
+                 ((1, 2), (3, 4))]:
+
+        assert merge(x, y, mode='reset') == y
+        assert merge(x, Reset(y)) == y
+        assert merge(x, Reset(y), mode='merge') == y
+
+        assert merge(x, y, mode='override') == y
+        assert merge(x, Override(y)) == y
+        assert merge(x, Override(y), mode='merge') == y
+
+    a = {'a': 1}
+    b = {'b': 2}
+    c = {'a': 1, 'b': 2}
+
+    assert merge(a, b, mode='reset') == b
+    assert merge(a, b, mode='override') == c
+
+    a = {'a': [1, 2], 'b': [3, 4]}
+    b = {'a': [5, 6], 'b': Override([7, 8])}
+    c = {'a': [1, 2, 5, 6], 'b': [7, 8]}
+    d = {'a': [5, 6], 'b': [7, 8]}
+
+    assert merge(a, b) == c
+    assert merge(a, b, mode='override') == d
+
+
+def test_cleanup():
+    a = dict(a=1, b=[2, Merge(3)], c=Override(4), d=DELETE)
+    assert cleanup(a) == dict(a=1, b=[2, 3], c=4)
+
+
+def test_cleanup_subclass():
+    a = TypeMap({int: Merge("int")})
+    ca = cleanup(a)
+    assert isinstance(ca, TypeMap)
+    assert ca == TypeMap({int: "int"})
+
+
+def test_Partial():
+
+    def f(x, y):
+        return x + y
+
+    p1 = Partial(f, x=10)
+    p2 = Partial(f, y=20)
+
+    assert p1(y=3) == 13
+    assert p2(x=3) == 23
+    assert merge(p1, p2)() == 30
+    assert merge(p1, {'y': 20})() == 30
+
+    with pytest.raises(TypeError):
+        Partial(f, z=10)
+
+    p3 = Reset(Partial(f, y=20))
+    with pytest.raises(TypeError):
+        merge(p1, p3)()
+
+    p4 = Partial(f, x=[1, 2])
+    p5 = Partial(f, x=[3, 4])
+
+    assert merge(p4, p5)(y=[10]) == [1, 2, 3, 4, 10]
+    assert merge(p5, p4)(y=[10]) == [3, 4, 1, 2, 10]
+
+    p6 = Override(Partial(f, x=[3, 4]))
+    assert merge(p4, p6)(y=[10]) == [3, 4, 10]
+
+    def g(x, y):
+        return x * y
+
+    p7 = Partial(g, y=20)
+    with pytest.raises(ValueError):
+        merge(p1, p7)
+
+    p8 = Override(Partial(g, y=20))
+    assert merge(p1, p8)() == 200
+
+    def h(**kw):
+        return kw
+
+    p9 = Partial(h, x=10)
+    assert p9(y=20, z=30) == dict(x=10, y=20, z=30)
+
+
+def test_Partial_class():
+
+    class C:
+        def __init__(self, x, y):
+            self.x = x
+            self.y = y
+
+        def __call__(self):
+            return self.x + self.y
+
+    p1 = Partial(C, x=10)
+    p2 = Partial(C, y=20)
+
+    assert p1(y=3)() == 13
+    assert p2(x=3)() == 23
+    assert merge(p1, p2)()() == 30
+
+    with pytest.raises(TypeError):
+        Partial(C, z=10)
+
+
+def test_Pipeline(op_pipeline):
+    pdef = op_pipeline
+
+    pip = pdef.make()
+    assert pip(value=3) == {'value': 64}
+
+    assert pip.steps.addp(value=3) == {'value': 4}
+    assert pip.steps.mulp(value=3) == {'value': 8}
+    assert pip.steps.neg(value=3) == {'value': -8}
+    assert pip.steps.square(value=3) == {'value': 64}
+
+    assert pip['addp'](value=3) == {'value': 4}
+    assert pip['mulp'](value=3) == {'value': 8}
+    assert pip['neg'](value=3) == {'value': -8}
+    assert pip['square'](value=3) == {'value': 64}
+
+    assert pip['mulp':](value=3) == {'value': 36}
+    assert pip[:'mulp'](value=3) == {'value': 8}
+    assert pip[:-1](value=3) == {'value': -8}
+    assert pip['mulp':'neg'](value=3) == {'value': -6}
+
+    assert pip['!square'](value=3) == {'value': -8}
+    assert pip['mulp':'!neg'](value=3) == {'value': 6}
+
+    assert pdef['mulp':'neg'].make()(value=3) == {'value': -6}
+
+
+def test_Pipeline_configure(op_pipeline):
+    pdef = op_pipeline
+
+    pip = pdef.configure(addp=Merge(param=2)).make()
+    assert pip(value=3) == {'value': 100}
+
+    pip = pdef.configure({'addp.param': 2}).make()
+    assert pip(value=3) == {'value': 100}
+
+    pip = pdef.configure(
+        {'addp.param': 2},
+        addp=Merge(op=lambda p, x: p - x)
+    ).make()
+    assert pip(value=3) == {'value': 4}
+
+    pip = pdef.configure(addp=Reset(op=lambda p, x: p - x, param=2)).make()
+    assert pip(value=3) == {'value': 4}
+
+    with pytest.raises(TypeError):
+        pdef.configure(addp=Reset(param=2)).make()
+
+    pip = pdef.configure(mulp=False).make()
+    assert pip(value=3) == {'value': 16}
+
+    pip = pdef.configure(mulp=False).configure(mulp=True).make()
+    assert pip(value=3) == {'value': 64}
+
+    pip = pdef.configure(mulp=False).configure(addp=False).make()
+    assert pip(value=3) == {'value': 9}
+
+    pip = pdef.configure(param=3).make()
+    assert pip(value=3) == {'value': 144}
+
+    with pytest.raises(KeyError):
+        pdef.configure(quack=[1, 2])
+
+    pdef2 = pdef.configure_resources(quack=[1, 2])
+    assert pdef2.make().resources.quack == [1, 2]
+    assert pdef2.configure(quack=[3]).make().resources.quack == [1, 2, 3]
+    assert pdef2.configure(quack=Reset([3])).make().resources.quack == [3]
+
+
+def test_Pipeline_insert(op_pipeline):
+    pdef = op_pipeline
+
+    half = OpStep.partial(op=lambda p, x: x / p, param=2)
+
+    pip = pdef.insert_before(half=half).make()
+    assert pip(value=3) == {'value': 25}
+
+    pip = pdef.insert_after(half=half).make()
+    assert pip(value=3) == {'value': 32}
+
+    pip = pdef.insert_before('addp', half=half).make()
+    assert pip(value=3) == {'value': 25}
+
+    pip = pdef.insert_after('addp', half=half).make()
+    assert pip(value=3) == {'value': 16}
+
+    pip = pdef.insert_before('square', half=half).make()
+    assert pip(value=3) == {'value': 16}
+
+    pip = pdef.insert_after('square', half=half).make()
+    assert pip(value=3) == {'value': 32}

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,6 +1,6 @@
 
 import pytest
-from myia.pipeline import merge, Partial, PipelineStep, \
+from myia.pipeline import merge, NS, Partial, PipelineStep, \
     PipelineDefinition, Merge, Reset, Override, DELETE, cleanup
 from myia.utils import TypeMap
 
@@ -108,6 +108,23 @@ def test_cleanup_subclass():
     assert ca == TypeMap({int: "int"})
 
 
+def test_NS():
+    ns = NS(x=1, y=2)
+
+    assert ns.x == 1
+    assert ns.y == 2
+
+    ns.a = 3
+    assert ns.a == 3
+    assert ns['a'] == 3
+
+    ns['b'] = 4
+    assert ns['b'] == 4
+    assert ns.b == 4
+
+    assert repr(ns) == 'NS(x=1, y=2, a=3, b=4)'
+
+
 def test_Partial():
 
     def f(x, y):
@@ -152,6 +169,8 @@ def test_Partial():
 
     p9 = Partial(h, x=10)
     assert p9(y=20, z=30) == dict(x=10, y=20, z=30)
+
+    str(p9), repr(p9)
 
 
 def test_Partial_class():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -194,6 +194,25 @@ def test_Partial_class():
         Partial(C, z=10)
 
 
+def test_PipelineDefinition_index(op_pipeline):
+    pdef = op_pipeline
+
+    assert pdef.index('addp') == 0
+    assert pdef.index('addp', True) == 1
+    assert pdef.index('!addp', True) == 0
+    assert pdef.index('mulp') == 1
+    assert pdef.index('neg') == 2
+    assert pdef.index('square') == 3
+
+    assert pdef.index(1) == 1
+
+    with pytest.raises(ValueError):
+        pdef.index('unknown')
+
+    with pytest.raises(TypeError):
+        pdef.index(object())
+
+
 def test_Pipeline(op_pipeline):
     pdef = op_pipeline
 


### PR DESCRIPTION
This defines a pipeline system for Myia. First you build a `PipelineDefinition`, then you call `make()` to create a `Pipeline` object, then you call that object with the required inputs, e.g. `pipeline_def.make()(input=fn, argspec={"type": Int(64)})`.

A `PipelineDefinition` can be configured. Given `myia.api.standard_pipeline`, which defines all stages, you can customize it in several ways:

```python
# Only run these steps: parse, closure convert, and export
pip1 = std.select('parse', 'cconv', 'export')

# Turn off optimization
pip2 = std.configure(opt=False)

# Run optimizations A and B (all three are equivalent)
# Merge means we concatenate [A, B] to previous opts (otherwise we'd be replacing them)
from myia.pipeline import Merge
pip3 = std.configure({'opt.opts': Merge([A, B])})
pip3 = std.configure(opt={'opts': Merge([A, B])})
pip3 = std.configure(opt=Merge(opts=[A, B]))

# Add a new optimization step
# Optimizer.partial creates a partial application of the Optimizer step
pip4 = std.insert_after('opt', opt2=Optimizer.partial(opts=[A, B]))

# Change how deep the value inferrer goes
pip5 = std.configure({'infer.tracks.value.max_depth': 10})
```

`select`, `configure`, `insert_before`, `insert_after` can all be chained.

A pipeline also contains resources which are shared between all stages. Each stage has access to the pipeline object, and to the resources in their `resources` field. `standard_pipeline` defines the resources `py_implementations` that maps primitives to their implementations, and `convert` which can be used to parse functions or convert data structures to Myia's format.
