### PR TITLE
Only take type property into account in specialize (fixes #87)

### DIFF
--- a/myia/infer.py
+++ b/myia/infer.py
@@ -299,11 +299,6 @@ class Reference:
         g = node.value if is_constant_graph(node) else node.graph
         self.context = context.filter(g)
 
-    async def get_all(self):
-        """Return all properties associated to this reference."""
-        return {track: await self[track]
-                for track in self.engine.all_track_names}
-
     def __getitem__(self, track):
         return self.engine.get(track, self)
 
@@ -333,10 +328,6 @@ class VirtualReference:
 
     async def __getitem__(self, track):
         return self.values[track]
-
-    async def get_all(self):
-        """Return all properties associated to this reference."""
-        return self.values
 
 
 ########

--- a/myia/specialize.py
+++ b/myia/specialize.py
@@ -128,8 +128,7 @@ class _GraphSpecializer:
             # the same inferred type/value/etc., we can merge their entries.
             cache = {}
             for x, y in t.cache.items():
-                key = tuple([tuple(sorted((await arg.get_all()).items()))
-                             for arg in x])
+                key = tuple([await arg['type'] for arg in x])
                 if key in cache:
                     assert cache[key] == y
                 cache[key] = y

--- a/tests/test_specialize.py
+++ b/tests/test_specialize.py
@@ -195,3 +195,20 @@ def test_indirect_graph(x):
         return f
 
     return f2()(x)
+
+
+@specialize((True, int1, int1))
+def test_poly_with_constants(c, x, y):
+    def f1(x, y):
+        return x + y
+
+    def f2(x, y):
+        return y + x
+
+    def choose(c):
+        if c:
+            return f1
+        else:
+            return f2
+
+    return choose(c)(x, 2), choose(not c)(2, y)


### PR DESCRIPTION
Previously, the specializer would fail to specialize graphs when called with the same type signatures but different value signatures.