### PR TITLE
Infer resolve and getattr

### DIFF
--- a/myia/api.py
+++ b/myia/api.py
@@ -3,7 +3,7 @@
 import operator
 from types import FunctionType
 
-from . import parser
+from . import dtype, parser
 from .cconv import closure_convert
 from .infer import InferenceEngine
 from .ir import Graph, clone, GraphManager
@@ -38,6 +38,29 @@ default_object_map = {
     operator.setitem: P.setitem,
     getattr: P.getattr,
     setattr: P.setattr,
+}
+
+
+_number_map = {
+    '__add__': P.add,
+    '__sub__': P.sub,
+    '__mul__': P.mul,
+    '__div__': P.div,
+}
+
+
+default_method_map = {
+    dtype.Int(8): _number_map,
+    dtype.Int(16): _number_map,
+    dtype.Int(32): _number_map,
+    dtype.Int(64): _number_map,
+    dtype.UInt(8): _number_map,
+    dtype.UInt(16): _number_map,
+    dtype.UInt(32): _number_map,
+    dtype.UInt(64): _number_map,
+    dtype.Float(16): _number_map,
+    dtype.Float(32): _number_map,
+    dtype.Float(64): _number_map,
 }
 
 
@@ -288,7 +311,8 @@ standard_pipeline = PipelineDefinition(
         convert=Converter.partial(
             object_map=default_object_map,
             converters=lax_type_map
-        )
+        ),
+        method_map=default_method_map
     ),
     steps=dict(
         parse=step_parse,

--- a/myia/dtype.py
+++ b/myia/dtype.py
@@ -250,6 +250,12 @@ class Unknown(Type):
     """Represents an unknown type (prior to type inference)."""
 
 
+class External(Type):
+    """Represents a type external to Myia (essentially invalid)."""
+
+    t: Any
+
+
 DTYPE_MAP = dict(
     int8=Int(8),
     int16=Int(16),

--- a/myia/dtype.py
+++ b/myia/dtype.py
@@ -237,13 +237,18 @@ class Function(Type):
         return (tuple(args[0]), args[1])
 
 
-class Dead(Type):
-    """This is the type of a dead computation.
+class Problem(Type):
+    """This represents some kind of problematic type.
 
-    The type specializer may produce a dummy constant with this type when a
-    polymorphic function is given as a parameter to a function that fails to
-    use it.
+    For example, when the specializer tries to specialize a graph that is not
+    called anywhere, it won't have the information it needs to do that, so it
+    may produce the type Problem(DEAD). A Problem type may not end up being
+    a real problem: dead code won't be called anyway, so it doesn't matter if
+    we can't type it. Others may be real problems, e.g. Problem(POLY) which
+    happens when there are multiple ways to type a graph in a given context.
     """
+
+    kind: Any
 
 
 class Unknown(Type):

--- a/myia/infer.py
+++ b/myia/infer.py
@@ -234,9 +234,9 @@ class PartialInferrer(Inferrer):
     prepending some arguments to all calls.
     """
 
-    def __init__(self, engine, fn, args):
+    def __init__(self, track, fn, args):
         """Initialize the PartialInferrer."""
-        super().__init__(engine, 'partial')
+        super().__init__(track, 'partial')
         self.fn = fn
         self.args = tuple(args)
 

--- a/myia/infer.py
+++ b/myia/infer.py
@@ -693,7 +693,8 @@ class InferenceEngine:
             inf = await self.get(track, self.ref(n_fn, ctx))
             if inf is ANYTHING:
                 return ANYTHING
-            assert isinstance(inf, Inferrer)
+            if not isinstance(inf, Inferrer):
+                raise AssertionError(f'Not an inferrer: {inf}')
             argrefs = [self.ref(node, ctx) for node in n_args]
             try:
                 return await inf(*argrefs)

--- a/myia/infer.py
+++ b/myia/infer.py
@@ -39,6 +39,29 @@ def type_error_nargs(ident, expected, got):
     )
 
 
+class ValueWrapper:
+    """Wrapper for an inferred value.
+
+    Values may be wrapped using subclasses of ValueWrapper, associating them
+    with tracking data or metadata.
+    """
+
+    def __init__(self, value):
+        """Initialize a ValueWrapper."""
+        self.value = value
+
+    def __hash__(self):
+        return hash(self.value)
+
+    def __eq__(self, other):
+        return type(other) is type(self) \
+            and self.value == other.value
+
+    @property
+    def __unwrapped__(self):
+        return self.value
+
+
 #########
 # Track #
 #########

--- a/myia/prim/inferrer_utils.py
+++ b/myia/prim/inferrer_utils.py
@@ -1,0 +1,55 @@
+"""Utilities that may leveraged by several inferrers."""
+
+
+from ..infer import InferenceError, PartialInferrer, Context, ANYTHING
+
+
+async def static_getter(track, data, item, fetch, chk=None):
+    """Return an inferrer for resolve or getattr.
+
+    Arguments:
+        track: The track on which the inference operates.
+        data: A ref to the data.
+        item: A ref to the item/attribute.
+        fetch: A function to resolve the item on the data.
+        chk: A function to check the values inferred for the
+            data and item.
+    """
+    resources = track.engine.pipeline.resources
+    mmap = resources.method_map
+
+    data_t = await data['type']
+    item_v = await item['value']
+    if item_v is ANYTHING:
+        raise InferenceError('Item or attribute must be known.')
+
+    if data_t in mmap:
+        # Method call
+        if chk:
+            chk(None, item_v)
+        if item_v in mmap[data_t]:
+            method = mmap[data_t][item_v]
+            inferrer = track.from_value(method, Context.empty())
+            inferrer = getattr(inferrer, '__unwrapped__', inferrer)
+            return PartialInferrer(
+                track,
+                inferrer,
+                [data]
+            )
+        else:
+            msg = f'Method {item_v} of {data_t} does not exist.'
+            raise InferenceError(msg)
+
+    else:
+        # Module or static namespace
+        data_v = await data['value']
+        if data_v is ANYTHING:
+            raise InferenceError('Data must be known.')
+        if chk:
+            chk(data_v, item_v)
+        try:
+            raw = fetch(data_v, item_v)
+        except Exception as e:
+            raise InferenceError('Getter error', e)
+        value = resources.convert(raw)
+        return track.from_value(value, Context.empty())

--- a/myia/prim/py_implementations.py
+++ b/myia/prim/py_implementations.py
@@ -137,7 +137,7 @@ def typeof(x):
             raise TypeError(f'All list elements should have same type')
         return types.List(type0)
     else:
-        raise TypeError(f'Untypable value: {x}')
+        return types.External(type(x))
 
 
 def hastype_helper(t, model):

--- a/myia/prim/py_implementations.py
+++ b/myia/prim/py_implementations.py
@@ -174,10 +174,16 @@ def tail(tup):
     return tup[1:]
 
 
-@register(primops.getitem)
+@py_register(primops.getitem)
 def getitem(data, item):
     """Implement `getitem`."""
     return data[item]
+
+
+@vm_register(primops.getitem)
+def _vm_getitem(vm, data, item):
+    """Implement `getitem`."""
+    return vm.convert(data[item])
 
 
 @register(primops.setitem)
@@ -192,14 +198,13 @@ def setitem(data, item, value):
         return data2
 
 
-py_getattr = getattr
-py_setattr = setattr
-
-
-@register(primops.getattr)
-def getattr(data, attr):
+@vm_register(primops.getattr)
+def _vm_getattr(vm, data, attr):
     """Implement `getattr`."""
-    return py_getattr(data, attr)
+    return vm.convert(getattr(data, attr))
+
+
+py_setattr = setattr
 
 
 @register(primops.setattr)

--- a/myia/prim/shape_inferrers.py
+++ b/myia/prim/shape_inferrers.py
@@ -10,6 +10,7 @@ from ..dtype import Array
 
 from . import ops as P
 from .ops import Primitive
+from .value_inferrers import _static_getter
 
 
 def prod(iterable):
@@ -166,3 +167,15 @@ async def infer_shape_dot(track, a, b):
             b_shp[0] is not ANYTHING):
         raise MyiaShapeError("Incompatible shapes in dot")
     return (a_shp[0], b_shp[1])
+
+
+@shape_inferrer(P.resolve, nargs=2)
+async def infer_shape_resolve(track, data, item):
+    """Infer the shape of resolve."""
+    return await _static_getter(track, data, item, lambda x, y: x[y])
+
+
+@shape_inferrer(P.getattr, nargs=2)
+async def infer_shape_getattr(track, data, item):
+    """Infer the shape of getattr."""
+    return await _static_getter(track, data, item, getattr)

--- a/myia/prim/shape_inferrers.py
+++ b/myia/prim/shape_inferrers.py
@@ -23,9 +23,9 @@ shape_inferrer_constructors = {}
 class ScalarShapeInferrer(Inferrer):
     """Shape inferrer for all primitives that don't take arrays."""
 
-    def __init__(self, engine):
+    def __init__(self, track):
         """Initialize the ScalarShapeInferrer."""
-        super().__init__(engine, 'scalar_shape_inferrer')
+        super().__init__(track, 'scalar_shape_inferrer')
 
     async def __call__(self, *args):
         """Since no arrays are involved, the shape is always ()."""
@@ -49,11 +49,11 @@ class ShapeTrack(Track):
         """Infer the shape of a constant."""
         if isinstance(v, Primitive):
             if v in self.constructors:
-                return self.constructors[v](self.engine)
+                return self.constructors[v](self)
             else:
-                return ScalarShapeInferrer(self.engine)
+                return ScalarShapeInferrer(self)
         elif isinstance(v, Graph):
-            return GraphInferrer(self.engine, 'shape', v, context)
+            return GraphInferrer(self, v, context)
         else:
             return getattr(v, 'shape', ())
 
@@ -63,13 +63,13 @@ shape_inferrer = partial(register_inferrer,
 
 
 @shape_inferrer(P.return_, nargs=1)
-async def infer_shape_return(engine, v):
+async def infer_shape_return(track, v):
     """Infer the shape of return."""
     return await v['shape']
 
 
 @shape_inferrer(P.if_, nargs=3)
-async def infer_shape_if(engine, cond, tb, fb):
+async def infer_shape_if(track, cond, tb, fb):
     """Infer the shape of if."""
     tb_inf = await tb['shape']
     fb_inf = await fb['shape']
@@ -83,7 +83,7 @@ async def infer_shape_if(engine, cond, tb, fb):
     elif v is ANYTHING:
         # The first branch to finish will return immediately. When the other
         # branch finishes, its result will be checked against the other.
-        return await engine.assert_same('shape', tb_inf(), fb_inf())
+        return await track.assert_same(tb_inf(), fb_inf())
     else:
         raise AssertionError("Invalid condition value for if.")
 
@@ -96,19 +96,19 @@ async def infer_shape_partial(engine, fn, *args):
 
 
 @shape_inferrer(P.map_array, nargs=2)
-async def infer_shape_map_array(engine, fn, ary):
+async def infer_shape_map_array(track, fn, ary):
     """Infer the shape of map_array."""
     return await ary['shape']
 
 
 @shape_inferrer(P.scan_array, nargs=4)
-async def infer_shape_scan_array(engine, fn, init, ary, ax):
+async def infer_shape_scan_array(track, fn, init, ary, ax):
     """Infer the shape of scan_array."""
     return await ary['shape']
 
 
 @shape_inferrer(P.reduce_array, nargs=4)
-async def infer_shape_reduce_array(engine, fn, init, ary, ax):
+async def infer_shape_reduce_array(track, fn, init, ary, ax):
     """Infer the shape of reduce_array."""
     shp = await ary['shape']
     ax_v = await ax['value']
@@ -121,7 +121,7 @@ async def infer_shape_reduce_array(engine, fn, init, ary, ax):
 
 
 @shape_inferrer(P.distribute, nargs=2)
-async def infer_shape_distribute(engine, v, shape):
+async def infer_shape_distribute(track, v, shape):
     """Infer the shape of distribute."""
     shp = await shape['value']
     if shp == ANYTHING:
@@ -139,7 +139,7 @@ async def infer_shape_distribute(engine, v, shape):
 
 
 @shape_inferrer(P.reshape, nargs=2)
-async def infer_shape_reshape(engine, v, shape):
+async def infer_shape_reshape(track, v, shape):
     """Infer the shape of reshape."""
     shp = await shape['value']
     if shp == ANYTHING:
@@ -155,7 +155,7 @@ async def infer_shape_reshape(engine, v, shape):
 
 
 @shape_inferrer(P.dot, nargs=2)
-async def infer_shape_dot(engine, a, b):
+async def infer_shape_dot(track, a, b):
     """Infer the shape of dot."""
     a_shp = await a['shape']
     b_shp = await b['shape']

--- a/myia/prim/shape_inferrers.py
+++ b/myia/prim/shape_inferrers.py
@@ -9,8 +9,8 @@ from ..ir import Graph
 from ..dtype import Array
 
 from . import ops as P
+from .inferrer_utils import static_getter
 from .ops import Primitive
-from .value_inferrers import _static_getter
 
 
 def prod(iterable):
@@ -172,10 +172,10 @@ async def infer_shape_dot(track, a, b):
 @shape_inferrer(P.resolve, nargs=2)
 async def infer_shape_resolve(track, data, item):
     """Infer the shape of resolve."""
-    return await _static_getter(track, data, item, lambda x, y: x[y])
+    return await static_getter(track, data, item, lambda x, y: x[y])
 
 
 @shape_inferrer(P.getattr, nargs=2)
 async def infer_shape_getattr(track, data, item):
     """Infer the shape of getattr."""
-    return await _static_getter(track, data, item, getattr)
+    return await static_getter(track, data, item, getattr)

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -5,9 +5,9 @@ from functools import partial
 
 from ..dtype import Int, Bool, Float, Tuple, List, Type, Array, UInt, Number
 from ..infer import ANYTHING, Inferrer, GraphInferrer, PartialInferrer, \
-    MyiaTypeError, register_inferrer, Track, Context
+    MyiaTypeError, register_inferrer, Track
 from ..ir import Graph
-from ..utils import Namespace, NS
+from ..utils import Namespace
 
 from . import ops as P
 from .ops import Primitive

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -10,9 +10,9 @@ from ..ir import Graph
 from ..utils import Namespace
 
 from . import ops as P
+from .inferrer_utils import static_getter
 from .ops import Primitive
 from .py_implementations import typeof
-from .value_inferrers import _static_getter
 
 
 type_inferrer_constructors = {}
@@ -305,7 +305,7 @@ async def infer_type_resolve(track, data, item):
             raise MyiaTypeError('data argument to resolve must be Namespace.')
         if not isinstance(item_v, str):  # pragma: no cover
             raise MyiaTypeError('item argument to resolve must be string.')
-    return await _static_getter(track, data, item, (lambda x, y: x[y]), chk)
+    return await static_getter(track, data, item, (lambda x, y: x[y]), chk)
 
 
 @type_inferrer(P.getattr, nargs=2)
@@ -314,4 +314,4 @@ async def infer_type_getattr(track, data, item):
     def chk(data_v, item_v):
         if not isinstance(item_v, str):
             raise MyiaTypeError('item argument to getattr must be string.')
-    return await _static_getter(track, data, item, getattr, chk)
+    return await static_getter(track, data, item, getattr, chk)

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -43,9 +43,9 @@ class TypeTrack(Track):
     def from_value(self, v, context):
         """Infer the type of a constant."""
         if isinstance(v, Primitive):
-            return self.constructors[v](self.engine)
+            return self.constructors[v](self)
         elif isinstance(v, Graph):
-            return GraphInferrer(self.engine, 'type', v, context)
+            return GraphInferrer(self, v, context)
         else:
             return typeof(v)
 
@@ -65,7 +65,7 @@ type_inferrer = partial(register_inferrer,
 
 
 @type_inferrer(P.if_, nargs=3)
-async def infer_type_if(engine, cond, tb, fb):
+async def infer_type_if(track, cond, tb, fb):
     """Infer the return type of if."""
     cond_t = await cond['type']
     if cond_t != Bool():
@@ -85,7 +85,7 @@ async def infer_type_if(engine, cond, tb, fb):
     elif v is ANYTHING:
         # The first branch to finish will return immediately. When the other
         # branch finishes, its result will be checked against the other.
-        return await engine.assert_same('type', tb_inf(), fb_inf())
+        return await track.assert_same(tb_inf(), fb_inf())
     else:
         raise AssertionError("Invalid condition value for if")
 
@@ -98,7 +98,7 @@ async def infer_type_partial(engine, fn, *args):
 
 
 @type_inferrer(P.cons_tuple, nargs=2)
-async def infer_type_cons_tuple(engine, x, y):
+async def infer_type_cons_tuple(track, x, y):
     """Infer the return type of cons_tuple."""
     x_t = await x['type']
     y_t = await y['type']
@@ -108,7 +108,7 @@ async def infer_type_cons_tuple(engine, x, y):
 
 
 @type_inferrer(P.head, nargs=1)
-async def infer_type_head(engine, tup):
+async def infer_type_head(track, tup):
     """Infer the return type of head."""
     tup_t = await tup['type']
     if not isinstance(tup_t, Tuple):
@@ -119,7 +119,7 @@ async def infer_type_head(engine, tup):
 
 
 @type_inferrer(P.tail, nargs=1)
-async def infer_type_tail(engine, tup):
+async def infer_type_tail(track, tup):
     """Infer the return type of tail."""
     tup_t = await tup['type']
     if not isinstance(tup_t, Tuple):
@@ -130,7 +130,7 @@ async def infer_type_tail(engine, tup):
 
 
 @type_inferrer(P.getitem, nargs=2)
-async def infer_type_getitem(engine, seq, idx):
+async def infer_type_getitem(track, seq, idx):
     """Infer the return type of getitem."""
     seq_t = await seq['type']
     idx_t = await idx['type']
@@ -149,13 +149,13 @@ async def infer_type_getitem(engine, seq, idx):
 
 
 @type_inferrer(P.typeof, nargs=1)
-async def infer_type_typeof(engine, _):
+async def infer_type_typeof(track, _):
     """Infer the return type of typeof."""
     return Type
 
 
 @type_inferrer(P.hastype, nargs=2)
-async def infer_type_hastype(engine, x, t):
+async def infer_type_hastype(track, x, t):
     """Infer the return type of hastype."""
     t_t = await t['type']
     if t_t is not Type:
@@ -166,7 +166,7 @@ async def infer_type_hastype(engine, x, t):
 
 
 @type_inferrer(P.not_, nargs=1)
-async def infer_type_not(engine, x):
+async def infer_type_not(track, x):
     """Infer the return type of not."""
     x_t = await x['type']
     if x_t != Bool():
@@ -175,23 +175,23 @@ async def infer_type_not(engine, x):
 
 
 @type_inferrer(P.eq, P.ne, nargs=2)
-async def infer_type_generic_compare(engine, x, y):
+async def infer_type_generic_compare(track, x, y):
     """Infer the return type of a generic comparison operator."""
-    await engine.assert_same('type', x, y)
+    await track.assert_same(x, y)
     return Bool()
 
 
 @type_inferrer(P.lt, P.gt, P.le, P.ge, nargs=2)
-async def infer_type_arith_compare(engine, x, y):
+async def infer_type_arith_compare(track, x, y):
     """Infer the return type of an arithmetic comparison operator."""
-    t = await engine.assert_same('type', x, y)
+    t = await track.assert_same(x, y)
     if not isinstance(t, (Int, Float)):
         raise MyiaTypeError('Expected number')
     return Bool()
 
 
 @type_inferrer(P.uadd, P.usub, nargs=1)
-async def infer_type_arith_unary(engine, x):
+async def infer_type_arith_unary(track, x):
     """Infer the return type of a unary arithmetic operator."""
     t = await x['type']
     if not isinstance(t, (Int, Float)):
@@ -200,34 +200,34 @@ async def infer_type_arith_unary(engine, x):
 
 
 @type_inferrer(P.add, P.sub, P.mul, P.div, P.mod, P.pow, nargs=2)
-async def infer_type_arith_bin(engine, x, y):
+async def infer_type_arith_bin(track, x, y):
     """Infer the return type of a binary arithmetic operator."""
-    t = await engine.assert_same('type', x, y)
+    t = await track.assert_same(x, y)
     if not isinstance(t, (Int, Float)):
         raise MyiaTypeError('Expected number')
     return t
 
 
 @type_inferrer(P.shape, nargs=1)
-async def infer_type_shape(engine, ary):
+async def infer_type_shape(track, ary):
     """Infer the return type of shape."""
     shp = await ary['shape']
     return Tuple([UInt(64)]*len(shp))
 
 
 @type_inferrer(P.map_array, nargs=2)
-async def infer_type_map_array(engine, fn, ary):
+async def infer_type_map_array(track, fn, ary):
     """Infer the return type of map_array."""
     fn_t = await fn['type']
     ary_t = await ary['type']
     if not isinstance(ary_t, Array):
         raise MyiaTypeError('Expected array')
-    xref = engine.vref({'type': ary_t.elements})
+    xref = track.engine.vref({'type': ary_t.elements})
     return Array(await fn_t(xref))
 
 
 @type_inferrer(P.scan_array, P.reduce_array, nargs=4)
-async def infer_type_across_array(engine, fn, init, ary, ax):
+async def infer_type_across_array(track, fn, init, ary, ax):
     """Infer the return type of scan/reduce_array."""
     fn_t = await fn['type']
     ary_t = await ary['type']
@@ -240,13 +240,13 @@ async def infer_type_across_array(engine, fn, init, ary, ax):
                             "as array elements")
     if not ax_t == UInt(64):
         raise MyiaTypeError("Axis must be u64")
-    xref = engine.vref({'type': ary_t.elements})
-    xref2 = engine.vref({'type': ary_t.elements})
+    xref = track.engine.vref({'type': ary_t.elements})
+    xref2 = track.engine.vref({'type': ary_t.elements})
     return Array(await fn_t(xref, xref2))
 
 
 @type_inferrer(P.distribute, nargs=2)
-async def infer_type_distribute(engine, v, shp):
+async def infer_type_distribute(track, v, shp):
     """Infer the return type of distribute."""
     v_t = await v['type']
     if isinstance(v_t, Array):
@@ -261,7 +261,7 @@ async def infer_type_distribute(engine, v, shp):
 
 
 @type_inferrer(P.reshape, nargs=2)
-async def infer_type_reshape(engine, v, shape):
+async def infer_type_reshape(track, v, shape):
     """Infer the return type of reshape."""
     shp_t = await shape['type']
     if (not isinstance(shp_t, Tuple) or
@@ -271,25 +271,25 @@ async def infer_type_reshape(engine, v, shape):
 
 
 @type_inferrer(P.dot, nargs=2)
-async def infer_type_dot(engine, a, b):
+async def infer_type_dot(track, a, b):
     """Infer the return type of dot."""
-    t = await engine.assert_same('type', a, b)
+    t = await track.assert_same(a, b)
     return t
 
 
 @type_inferrer(P.return_, nargs=1)
-async def infer_type_return_(engine, x):
+async def infer_type_return_(track, x):
     """Infer the return type of return_."""
     return await x['type']
 
 
 @type_inferrer(P.maplist, nargs=2)
-async def infer_type_maplist(engine, f, xs):
+async def infer_type_maplist(track, f, xs):
     """Infer the return type of maplist."""
     f_t = await f['type']
     xs_t = await xs['type']
     if not isinstance(xs_t, List):
         raise MyiaTypeError('Expect list for maplist')
-    xref = engine.vref(dict(type=xs_t.element_type))
+    xref = track.engine.vref(dict(type=xs_t.element_type))
     ret_t = await f_t(xref)
     return List(ret_t)

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -5,9 +5,9 @@ from functools import partial
 
 from ..dtype import Int, Bool, Float, Tuple, List, Type, Array, UInt, Number
 from ..infer import ANYTHING, Inferrer, GraphInferrer, PartialInferrer, \
-    MyiaTypeError, register_inferrer, Track
+    MyiaTypeError, register_inferrer, Track, Context
 from ..ir import Graph
-from ..utils import Namespace
+from ..utils import Namespace, NS
 
 from . import ops as P
 from .ops import Primitive
@@ -93,10 +93,10 @@ async def infer_type_if(track, cond, tb, fb):
 
 
 @type_inferrer(P.partial, nargs=None)
-async def infer_type_partial(engine, fn, *args):
+async def infer_type_partial(track, fn, *args):
     """Infer the return type of partial."""
     fn_t = await fn['type']
-    return PartialInferrer(engine, fn_t, args)
+    return PartialInferrer(track, fn_t, args)
 
 
 @type_inferrer(P.cons_tuple, nargs=2)

--- a/myia/prim/value_inferrers.py
+++ b/myia/prim/value_inferrers.py
@@ -62,9 +62,9 @@ class PrimitiveValueInferrer(Inferrer):
     The implementation will not be called.
     """
 
-    def __init__(self, engine, prim, impl):
+    def __init__(self, track, prim, impl):
         """Initialize a PrimitiveValueInferrer."""
-        super().__init__(engine, prim)
+        super().__init__(track, prim)
         self.impl = impl
 
     async def infer(self, *refs):
@@ -118,13 +118,13 @@ class ValueTrack(Track):
         engine = self.engine
         if isinstance(v, Primitive):
             if v in self.constructors:
-                inf = self.constructors[v](engine)
+                inf = self.constructors[v](self)
             else:
                 inf = PrimitiveValueInferrer(
-                    engine, v, self.implementations[v]
+                    self, v, self.implementations[v]
                 )
         elif isinstance(v, Graph):
-            inf = GraphInferrer(engine, 'value', v, context)
+            inf = GraphInferrer(self, v, context)
         else:
             return self.wrap(v)
 

--- a/myia/specialize.py
+++ b/myia/specialize.py
@@ -36,7 +36,9 @@ class TypeSpecializer:
         self.counts = Counter()
 
         empty_ctx = Context.empty()
-        ginf = GraphInferrer(self.engine, 'type', engine.graph, empty_ctx)
+        ginf = GraphInferrer(self.engine.tracks['type'],
+                             engine.graph,
+                             empty_ctx)
         argrefs = self.engine.argrefs
 
         self.result = self.engine.run_coroutine(

--- a/tests/prim/test_py_implementations.py
+++ b/tests/prim/test_py_implementations.py
@@ -3,7 +3,7 @@ import pytest
 from types import SimpleNamespace
 import numpy as np
 
-from myia.dtype import Int, Float, List, Tuple
+from myia.dtype import Int, Float, List, Tuple, External
 from myia.prim.py_implementations import head, setattr as myia_setattr, \
     setitem as myia_setitem, tail, hastype, typeof, \
     shape, reshape, map_array, scan_array, reduce_array, distribute, dot, \
@@ -129,8 +129,7 @@ def test_prim_typeof():
     assert typeof([1, 2]) == List(i64)
     with pytest.raises(TypeError):
         typeof([1, 2, 3.4])
-    with pytest.raises(TypeError):
-        typeof(object())
+    assert typeof(object()) == External(object)
 
 
 def test_prim_istype():
@@ -145,8 +144,7 @@ def test_prim_istype():
     assert hastype((1, 2.0, (3, 4)), Tuple(i64, f64, Tuple(i64, i64)))
     with pytest.raises(TypeError):
         hastype([1, 2, 3.4], List)
-    with pytest.raises(TypeError):
-        hastype(object(), i64)
+    assert hastype(object(), External(object))
 
 
 def test_prim_shape():

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -73,8 +73,8 @@ pyimpl_test[_tern] = impl_tern
 
 
 @type_inferrer_test(_tern, nargs=3)
-async def infer_type_tern(engine, x, y, z):
-    ret_t = await engine.assert_same('type', x, y, z)
+async def infer_type_tern(track, x, y, z):
+    ret_t = await track.assert_same(x, y, z)
     assert isinstance(ret_t, (Int, Float))
     return ret_t
 
@@ -92,7 +92,7 @@ pyimpl_test[_to_i64] = impl_to_i64
 
 
 @type_inferrer_test(_to_i64, nargs=1)
-async def infer_type_to_i64(engine, x):
+async def infer_type_to_i64(track, x):
     return Int(64)
 
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -896,6 +896,25 @@ def test_getattr_flex(name, x):
     return _getattr(helpers, name)(x, x)
 
 
+@infer(type=[
+    (External(SimpleNamespace),
+     {'type': External(str), 'value': 'surprise'},
+     InferenceError)
+])
+def test_unknown_data(data, field):
+    return _getattr(data, field)
+
+
+@infer(type=[(i64, i64, i64), (f64, f64, f64)])
+def test_method(x, y):
+    return x.__add__(y)
+
+
+@infer(type=[(i64, i64, InferenceError)])
+def test_unknown_method(x, y):
+    return x.unknown(y)
+
+
 @infer(type=[(i64, InferenceError)])
 def test_infinite_recursion(x):
     def ouroboros(x):


### PR DESCRIPTION
This adds support in the inferrer for the `resolve` and `getattr` primitives. This means the `infer` and `specialize` steps can now perform the work of the `resolve` step.