### PR TITLE
Support for more Python language features

### DIFF
--- a/myia/debug/label.py
+++ b/myia/debug/label.py
@@ -12,6 +12,7 @@ short_relation_symbols = {
     'copy': '',
     'cosmetic': '',
     'phi': 'Φ',
+    'iterator': '*',
     'fv': '⤋',
     'if_true': '✓',
     'if_false': '✗',
@@ -19,6 +20,9 @@ short_relation_symbols = {
     'while_header': '⤾',
     'while_body': '⥁',
     'while_after': '↓',
+    'for_header': '⤾',
+    'for_body': '⥁',
+    'for_after': '↓',
     'specialized': '+'
 }
 

--- a/myia/parser.py
+++ b/myia/parser.py
@@ -267,7 +267,7 @@ class Parser:
 
     def process_BoolOp(self, block: 'Block', node: ast.BinOp) -> ANFNode:
         """Process boolean operators: `a and b`, `a or b`."""
-        def fold(block, values, mode='and'):
+        def fold(block, values, mode):
             first, *rest = values
             test = self.process_node(block, first)
             if rest:

--- a/myia/prim/ops.py
+++ b/myia/prim/ops.py
@@ -68,6 +68,16 @@ getattr = Primitive('getattr')
 setattr = Primitive('setattr')
 
 
+#############
+# Iteration #
+#############
+
+
+iter = Primitive('iter')
+hasnext = Primitive('hasnext')
+next = Primitive('next')
+
+
 ##########
 # Arrays #
 ##########

--- a/myia/prim/py_implementations.py
+++ b/myia/prim/py_implementations.py
@@ -332,3 +332,23 @@ def partial(f, *args):
     def res(*others):
         return f(*(args + others))
     return res
+
+
+@vm_register(primops.iter)
+def _iter_vm(vm, xs):
+    """Implement `iter`."""
+    return (0, xs)
+
+
+@vm_register(primops.hasnext)
+def _hasnext_vm(vm, it):
+    """Implement `hasnext`."""
+    n, data = it
+    return n < len(data)
+
+
+@vm_register(primops.next)
+def _next_vm(vm, it):
+    """Implement `next`."""
+    n, data = it
+    return (data[n], (n + 1, data))

--- a/myia/prim/py_implementations.py
+++ b/myia/prim/py_implementations.py
@@ -334,21 +334,21 @@ def partial(f, *args):
     return res
 
 
-@vm_register(primops.iter)
-def _iter_vm(vm, xs):
+@register(primops.iter)
+def _iter(xs):
     """Implement `iter`."""
     return (0, xs)
 
 
-@vm_register(primops.hasnext)
-def _hasnext_vm(vm, it):
+@register(primops.hasnext)
+def _hasnext(it):
     """Implement `hasnext`."""
     n, data = it
     return n < len(data)
 
 
-@vm_register(primops.next)
-def _next_vm(vm, it):
+@register(primops.next)
+def _next(it):
     """Implement `next`."""
     n, data = it
     return (data[n], (n + 1, data))

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -315,3 +315,38 @@ async def infer_type_getattr(track, data, item):
         if not isinstance(item_v, str):
             raise MyiaTypeError('item argument to getattr must be string.')
     return await static_getter(track, data, item, getattr, chk)
+
+
+@type_inferrer(P.iter, nargs=1)
+async def infer_type_iter(engine, xs):
+    """Infer the return type of iter."""
+    xs_t = await xs['type']
+    if isinstance(xs_t, List):
+        return Tuple([Int(64), xs_t])
+    else:
+        raise MyiaTypeError('Unsupported type for iter')
+
+
+@type_inferrer(P.hasnext, nargs=1)
+async def infer_type_hasnext(engine, it):
+    """Infer the return type of hasnext."""
+    it_t = await(it['type'])
+    if isinstance(it_t, Tuple) \
+            and len(it_t.elements) == 2 \
+            and isinstance(it_t.elements[1], List):
+        return Bool()
+    else:  # pragma: no cover
+        raise MyiaTypeError('Unsupported iterator type for hasnext')
+
+
+@type_inferrer(P.next, nargs=1)
+async def infer_type_next(engine, it):
+    """Infer the return type of next."""
+    it_t = await(it['type'])
+    if isinstance(it_t, Tuple) \
+            and len(it_t.elements) == 2 \
+            and isinstance(it_t.elements[1], List):
+        x_t = it_t.elements[1].element_type
+        return Tuple([x_t, it_t])
+    else:  # pragma: no cover
+        raise MyiaTypeError('Unsupported iterator type for next')

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -264,6 +264,20 @@ def test_while(x, y):
     return rval
 
 
+@infer(
+    type=[
+        (li64, i64, i64),
+        (li64, f64, InferenceError),
+        (i64, i64, InferenceError),
+    ]
+)
+def test_for(xs, y):
+    rval = y
+    for x in xs:
+        rval = rval + x
+    return rval
+
+
 @infer(type=(i64, f64, T(i64, f64)))
 def test_nullary_closure(x, y):
     def make(z):

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -210,6 +210,26 @@ def test_max(x, y):
         return y
 
 
+@parse_compare((7, 3), (-1, 3))
+def test_ifexpr(x, y):
+    return x * x if x > 0 else y * y
+
+
+@parse_compare((7, 3), (1, 3))
+def test_max_expr(x, y):
+    return x if x > y else y
+
+
+@parse_compare((7, 3), (-1, 3), (-3, 1), (-1, -1))
+def test_and(x, y):
+    return x > 0 and y > 0
+
+
+@parse_compare((7, 3), (-1, 3), (-3, 1), (-1, -1))
+def test_or(x, y):
+    return x > 0 or y > 0
+
+
 ###################
 # while statement #
 ###################
@@ -371,6 +391,23 @@ def test_fn5():
             return y + 1
         return f(x + 1)
     return g(2)
+
+
+###########
+# Lambda #
+###########
+
+
+@parse_compare((5,))
+def test_lambda(x):
+    f = lambda y: x + y  # noqa
+    return f(x)
+
+
+@parse_compare((5,))
+def test_lambda2(x):
+    f = lambda y, z: x + y * z  # noqa
+    return f(10, x)
 
 
 #############

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -282,6 +282,19 @@ def test_if_return_in_while(x):
     return -1
 
 
+#################
+# for statement #
+#################
+
+
+@parse_compare(([1, 2, 3, 4],))
+def test_for(xs):
+    result = 0
+    for x in xs:
+        result = result + x
+    return result
+
+
 ############
 # closures #
 ############


### PR DESCRIPTION
This adds support for the following language features:

* Conditional expressions: `a if cond else b`
* Boolean expressions: `a and b or c`
* Lambda expressions: `lambda x, y: x + y`
* For loops: `for x in xs: a = a + x`

`for` loops are implemented using three new primitives, `iter`, `hasnext` and `next` (although they have a different interface from Python's `iter` and `next`, so it might be appropriate to rename them). Roughly speaking:

```python
for x in xs:
    a = a + x
```

Becomes:

```python
it = iter(xs)
while hasnext(it):
    x, it = next(it)
    a = a + x
```

Currently, `iter(xs)` just returns the tuple `(0, xs)` as a sort of ad hoc iterator object, and `next` increments the counter in the first element.
