### PR TITLE
Use a custom event loop for the inferrer

### DIFF
--- a/myia/api.py
+++ b/myia/api.py
@@ -159,12 +159,11 @@ class Inferrer(PipelineStep):
         inferrer: The inference engine.
     """
 
-    def __init__(self, pipeline_init, tracks, required_tracks, timeout):
+    def __init__(self, pipeline_init, tracks, required_tracks):
         """Initialize an Inferrer."""
         super().__init__(pipeline_init)
         self.tracks = tracks
         self.required_tracks = required_tracks
-        self.timeout = timeout
 
     def step(self, graph, argspec):
         """Infer types, shapes, values, etc. for the graph."""
@@ -174,7 +173,6 @@ class Inferrer(PipelineStep):
             graph, argprops,
             tracks=self.tracks,
             required_tracks=self.required_tracks,
-            timeout=self.timeout
         )
         return {'inference_results': engine.output_info(),
                 'inferrer': engine}
@@ -260,7 +258,6 @@ step_infer = Inferrer.partial(
         )
     ),
     required_tracks=['type'],
-    timeout=1
 )
 
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -103,7 +103,6 @@ infer_pipeline = standard_pipeline.select(
     'infer.tracks.value.max_depth': 10,
     'infer.tracks.value.constructors': value_inferrer_cons_test,
     'infer.tracks.type.constructors': type_inferrer_cons_test,
-    'infer.timeout': 0.1
 })
 
 


### PR DESCRIPTION
This implements `_InferenceLoop` as a subclass of `AbstractEventLoop` and uses that as the inferrer's event loop. This custom loop does not allow temporal scheduling and will not "hang" forever when it has nothing to do. Anyway, the bottom line is that the inferrer does not need a timeout argument anymore, and it also seems to be 10-20% faster which is nice.