### PR TITLE
Rename ops

### DIFF
--- a/myia/api.py
+++ b/myia/api.py
@@ -18,22 +18,23 @@ from .utils import TypeMap
 from .vm import VM
 from .compile import step_compile, step_link, step_export
 
+
 default_object_map = {
-    operator.add: P.add,
-    operator.sub: P.sub,
-    operator.mul: P.mul,
-    operator.truediv: P.div,
-    operator.mod: P.mod,
-    operator.pow: P.pow,
-    operator.eq: P.eq,
-    operator.ne: P.ne,
-    operator.lt: P.lt,
-    operator.gt: P.gt,
-    operator.le: P.le,
-    operator.ge: P.ge,
-    operator.pos: P.uadd,
-    operator.neg: P.usub,
-    operator.not_: P.not_,
+    operator.add: P.scalar_add,
+    operator.sub: P.scalar_sub,
+    operator.mul: P.scalar_mul,
+    operator.truediv: P.scalar_div,
+    operator.mod: P.scalar_mod,
+    operator.pow: P.scalar_pow,
+    operator.eq: P.scalar_eq,
+    operator.ne: P.scalar_ne,
+    operator.lt: P.scalar_lt,
+    operator.gt: P.scalar_gt,
+    operator.le: P.scalar_le,
+    operator.ge: P.scalar_ge,
+    operator.pos: P.scalar_uadd,
+    operator.neg: P.scalar_usub,
+    operator.not_: P.bool_not,
     operator.getitem: P.getitem,
     operator.setitem: P.setitem,
     getattr: P.getattr,
@@ -42,10 +43,10 @@ default_object_map = {
 
 
 _number_map = {
-    '__add__': P.add,
-    '__sub__': P.sub,
-    '__mul__': P.mul,
-    '__div__': P.div,
+    '__add__': P.scalar_add,
+    '__sub__': P.scalar_sub,
+    '__mul__': P.scalar_mul,
+    '__div__': P.scalar_div,
 }
 
 

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -101,7 +101,7 @@ tail_tuple = psub(
 
 # f((a, b, ...), (p, q, ...)) => (f(a, p), f(b, q), ...)
 # For f in the following list:
-_BubbleBinary = primset_var(P.add)
+_BubbleBinary = primset_var(P.scalar_add)
 
 bubble_op_cons_binary = psub(
     pattern=(_BubbleBinary, (P.cons_tuple, X1, Y1), (P.cons_tuple, X2, Y2)),
@@ -126,37 +126,37 @@ bubble_op_nil_binary = psub(
 
 
 multiply_by_zero_l = psub(
-    pattern=(P.mul, 0, X),
+    pattern=(P.scalar_mul, 0, X),
     replacement=0,
     name='multiply_by_zero_l'
 )
 
 multiply_by_zero_r = psub(
-    pattern=(P.mul, X, 0),
+    pattern=(P.scalar_mul, X, 0),
     replacement=0,
     name='multiply_by_zero_r'
 )
 
 multiply_by_one_l = psub(
-    pattern=(P.mul, 1, X),
+    pattern=(P.scalar_mul, 1, X),
     replacement=X,
     name='multiply_by_one_l'
 )
 
 multiply_by_one_r = psub(
-    pattern=(P.mul, X, 1),
+    pattern=(P.scalar_mul, X, 1),
     replacement=X,
     name='multiply_by_one_r'
 )
 
 add_zero_l = psub(
-    pattern=(P.add, 0, X),
+    pattern=(P.scalar_add, 0, X),
     replacement=X,
     name='add_zero_l'
 )
 
 add_zero_r = psub(
-    pattern=(P.add, X, 0),
+    pattern=(P.scalar_add, X, 0),
     replacement=X,
     name='add_zero_r'
 )

--- a/myia/prim/ops.py
+++ b/myia/prim/ops.py
@@ -84,9 +84,9 @@ next = Primitive('next')
 
 
 shape = Primitive('shape')
-map_array = Primitive('map_array')
-scan_array = Primitive('scan_array')
-reduce_array = Primitive('reduce_array')
+array_map = Primitive('array_map')
+array_scan = Primitive('array_scan')
+array_reduce = Primitive('array_reduce')
 distribute = Primitive('distribute')
 reshape = Primitive('reshape')
 dot = Primitive('dot')
@@ -105,6 +105,6 @@ return_ = Primitive('return')
 # Miscellaneous #
 #################
 
-maplist = Primitive('maplist')
+list_map = Primitive('list_map')
 resolve = Primitive('resolve')
 partial = Primitive('partial')

--- a/myia/prim/ops.py
+++ b/myia/prim/ops.py
@@ -21,14 +21,14 @@ class Primitive(Named):
 ##############
 
 
-add = Primitive('add')
-sub = Primitive('sub')
-mul = Primitive('mul')
-div = Primitive('div')
-mod = Primitive('mod')
-pow = Primitive('pow')
-uadd = Primitive('uadd')
-usub = Primitive('usub')
+scalar_add = Primitive('scalar_add')
+scalar_sub = Primitive('scalar_sub')
+scalar_mul = Primitive('scalar_mul')
+scalar_div = Primitive('scalar_div')
+scalar_mod = Primitive('scalar_mod')
+scalar_pow = Primitive('scalar_pow')
+scalar_uadd = Primitive('scalar_uadd')
+scalar_usub = Primitive('scalar_usub')
 
 
 ###############
@@ -36,13 +36,13 @@ usub = Primitive('usub')
 ###############
 
 
-eq = Primitive('eq')
-lt = Primitive('lt')
-gt = Primitive('gt')
-ne = Primitive('ne')
-le = Primitive('le')
-ge = Primitive('ge')
-not_ = Primitive('not')
+scalar_eq = Primitive('scalar_eq')
+scalar_lt = Primitive('scalar_lt')
+scalar_gt = Primitive('scalar_gt')
+scalar_ne = Primitive('scalar_ne')
+scalar_le = Primitive('scalar_le')
+scalar_ge = Primitive('scalar_ge')
+bool_not = Primitive('bool_not')
 
 
 ######################

--- a/myia/prim/py_implementations.py
+++ b/myia/prim/py_implementations.py
@@ -249,9 +249,9 @@ def shape(array):
     return array.shape
 
 
-@py_register(primops.map_array)
-def map_array(fn, array):
-    """Implement `map_array`."""
+@py_register(primops.array_map)
+def array_map(fn, array):
+    """Implement `array_map`."""
     def f(ary):
         it = np.nditer([ary, None])
         for x, y in it:
@@ -260,16 +260,16 @@ def map_array(fn, array):
     return np.apply_along_axis(f, 0, array)
 
 
-@vm_register(primops.map_array)
-def _map_array_vm(vm, fn, array):
+@vm_register(primops.array_map)
+def _array_map_vm(vm, fn, array):
     def fn_(x):
         return vm.call(fn, (x,))
-    return map_array(fn_, array)
+    return array_map(fn_, array)
 
 
-@py_register(primops.scan_array)
-def scan_array(fn, init, array, axis):
-    """Implement `scan_array`."""
+@py_register(primops.array_scan)
+def array_scan(fn, init, array, axis):
+    """Implement `array_scan`."""
     # This is inclusive scan because it's easier to implement
     # We will have to discuss what semantics we want later
     def f(ary):
@@ -282,16 +282,16 @@ def scan_array(fn, init, array, axis):
     return np.apply_along_axis(f, axis, array)
 
 
-@vm_register(primops.scan_array)
-def _scan_array_vm(vm, fn, init, array, axis):
+@vm_register(primops.array_scan)
+def _array_scan_vm(vm, fn, init, array, axis):
     def fn_(a, b):
         return vm.call(fn, [a, b])
-    return scan_array(fn_, init, array, axis)
+    return array_scan(fn_, init, array, axis)
 
 
-@py_register(primops.reduce_array)
-def reduce_array(fn, init, array, axis):
-    """Implement `reduce_array`."""
+@py_register(primops.array_reduce)
+def array_reduce(fn, init, array, axis):
+    """Implement `array_reduce`."""
     def f(ary):
         val = init
         it = np.nditer([ary])
@@ -301,11 +301,11 @@ def reduce_array(fn, init, array, axis):
     return np.apply_along_axis(f, axis, array)
 
 
-@vm_register(primops.reduce_array)
-def _reduce_array_vm(vm, fn, init, array, axis):
+@vm_register(primops.array_reduce)
+def _array_reduce_vm(vm, fn, init, array, axis):
     def fn_(a, b):
         return vm.call(fn, [a, b])
-    return reduce_array(fn_, init, array, axis)
+    return array_reduce(fn_, init, array, axis)
 
 
 @register(primops.distribute)
@@ -332,15 +332,15 @@ def return_(x):
     return x
 
 
-@py_register(primops.maplist)
-def maplist(f, xs):
-    """Implement `maplist` in pure Python."""
+@py_register(primops.list_map)
+def list_map(f, xs):
+    """Implement `list_map` in pure Python."""
     return list(map(f, xs))
 
 
-@vm_register(primops.maplist)
-def _maplist_vm(vm, f, xs):
-    """Implement `maplist` for Myia's VM."""
+@vm_register(primops.list_map)
+def _list_map_vm(vm, f, xs):
+    """Implement `list_map` for Myia's VM."""
     def f_(*args):
         return vm.call(f, args)
     return list(map(f_, xs))

--- a/myia/prim/py_implementations.py
+++ b/myia/prim/py_implementations.py
@@ -28,93 +28,121 @@ def register(prim):
     return deco
 
 
-@register(primops.add)
-def add(x, y):
-    """Implement `add`."""
+def _assert_scalar(*args):
+    # TODO: These checks should be stricter, e.g. require that all args
+    # have exactly the same type, but right now there is some mixing between
+    # numpy types and int/float.
+    for x in args:
+        if isinstance(x, np.ndarray):
+            if x.shape != ():
+                msg = f'Expected scalar, not array with shape {x.shape}'
+                raise TypeError(msg)
+        elif not isinstance(x, (int, float)):
+            raise TypeError(f'Expected scalar, not {type(x)}')
+
+
+@register(primops.scalar_add)
+def scalar_add(x, y):
+    """Implement `scalar_add`."""
+    _assert_scalar(x, y)
     return x + y
 
 
-@register(primops.sub)
-def sub(x, y):
-    """Implement `sub`."""
+@register(primops.scalar_sub)
+def scalar_sub(x, y):
+    """Implement `scalar_sub`."""
+    _assert_scalar(x, y)
     return x - y
 
 
-@register(primops.mul)
-def mul(x, y):
-    """Implement `mul`."""
+@register(primops.scalar_mul)
+def scalar_mul(x, y):
+    """Implement `scalar_mul`."""
+    _assert_scalar(x, y)
     return x * y
 
 
-@register(primops.div)
-def div(x, y):
-    """Implement `div`."""
+@register(primops.scalar_div)
+def scalar_div(x, y):
+    """Implement `scalar_div`."""
+    _assert_scalar(x, y)
     return x / y
 
 
-@register(primops.mod)
-def mod(x, y):
-    """Implement `mod`."""
+@register(primops.scalar_mod)
+def scalar_mod(x, y):
+    """Implement `scalar_mod`."""
+    _assert_scalar(x, y)
     return x % y
 
 
-@register(primops.pow)
-def pow(x, y):
-    """Implement `pow`."""
+@register(primops.scalar_pow)
+def scalar_pow(x, y):
+    """Implement `scalar_pow`."""
+    _assert_scalar(x, y)
     return x ** y
 
 
-@register(primops.uadd)
-def uadd(x):
-    """Implement `iadd`."""
+@register(primops.scalar_uadd)
+def scalar_uadd(x):
+    """Implement `scalar_uadd`."""
+    _assert_scalar(x)
     return x
 
 
-@register(primops.usub)
-def usub(x):
-    """Implement `isub`."""
+@register(primops.scalar_usub)
+def scalar_usub(x):
+    """Implement `scalar_usub`."""
+    _assert_scalar(x)
     return -x
 
 
-@register(primops.eq)
-def eq(x, y):
-    """Implement `eq`."""
+@register(primops.scalar_eq)
+def scalar_eq(x, y):
+    """Implement `scalar_eq`."""
+    _assert_scalar(x, y)
     return x == y
 
 
-@register(primops.lt)
-def lt(x, y):
-    """Implement `lt`."""
+@register(primops.scalar_lt)
+def scalar_lt(x, y):
+    """Implement `scalar_lt`."""
+    _assert_scalar(x, y)
     return x < y
 
 
-@register(primops.gt)
-def gt(x, y):
-    """Implement `gt`."""
+@register(primops.scalar_gt)
+def scalar_gt(x, y):
+    """Implement `scalar_gt`."""
+    _assert_scalar(x, y)
     return x > y
 
 
-@register(primops.ne)
-def ne(x, y):
-    """Implement `ne`."""
+@register(primops.scalar_ne)
+def scalar_ne(x, y):
+    """Implement `scalar_ne`."""
+    _assert_scalar(x, y)
     return x != y
 
 
-@register(primops.le)
-def le(x, y):
-    """Implement `le`."""
+@register(primops.scalar_le)
+def scalar_le(x, y):
+    """Implement `scalar_le`."""
+    _assert_scalar(x, y)
     return x <= y
 
 
-@register(primops.ge)
-def ge(x, y):
-    """Implement `ge`."""
+@register(primops.scalar_ge)
+def scalar_ge(x, y):
+    """Implement `scalar_ge`."""
+    _assert_scalar(x, y)
     return x >= y
 
 
-@register(primops.not_)
-def not_(x):
-    """Implement `not_`."""
+@register(primops.bool_not)
+def bool_not(x):
+    """Implement `bool_not`."""
+    assert x is True or x is False
     return not x
 
 

--- a/myia/prim/shape_inferrers.py
+++ b/myia/prim/shape_inferrers.py
@@ -96,21 +96,21 @@ async def infer_shape_partial(engine, fn, *args):
     return PartialInferrer(engine, fn_t, args)
 
 
-@shape_inferrer(P.map_array, nargs=2)
-async def infer_shape_map_array(track, fn, ary):
-    """Infer the shape of map_array."""
+@shape_inferrer(P.array_map, nargs=2)
+async def infer_shape_array_map(track, fn, ary):
+    """Infer the shape of array_map."""
     return await ary['shape']
 
 
-@shape_inferrer(P.scan_array, nargs=4)
-async def infer_shape_scan_array(track, fn, init, ary, ax):
-    """Infer the shape of scan_array."""
+@shape_inferrer(P.array_scan, nargs=4)
+async def infer_shape_array_scan(track, fn, init, ary, ax):
+    """Infer the shape of array_scan."""
     return await ary['shape']
 
 
-@shape_inferrer(P.reduce_array, nargs=4)
-async def infer_shape_reduce_array(track, fn, init, ary, ax):
-    """Infer the shape of reduce_array."""
+@shape_inferrer(P.array_reduce, nargs=4)
+async def infer_shape_array_reduce(track, fn, init, ary, ax):
+    """Infer the shape of array_reduce."""
     shp = await ary['shape']
     ax_v = await ax['value']
     if ax_v == ANYTHING:

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -167,7 +167,7 @@ async def infer_type_hastype(track, x, t):
     return Bool()
 
 
-@type_inferrer(P.not_, nargs=1)
+@type_inferrer(P.bool_not, nargs=1)
 async def infer_type_not(track, x):
     """Infer the return type of not."""
     x_t = await x['type']
@@ -176,14 +176,14 @@ async def infer_type_not(track, x):
     return Bool()
 
 
-@type_inferrer(P.eq, P.ne, nargs=2)
+@type_inferrer(P.scalar_eq, P.scalar_ne, nargs=2)
 async def infer_type_generic_compare(track, x, y):
     """Infer the return type of a generic comparison operator."""
     await track.assert_same(x, y)
     return Bool()
 
 
-@type_inferrer(P.lt, P.gt, P.le, P.ge, nargs=2)
+@type_inferrer(P.scalar_lt, P.scalar_gt, P.scalar_le, P.scalar_ge, nargs=2)
 async def infer_type_arith_compare(track, x, y):
     """Infer the return type of an arithmetic comparison operator."""
     t = await track.assert_same(x, y)
@@ -192,7 +192,7 @@ async def infer_type_arith_compare(track, x, y):
     return Bool()
 
 
-@type_inferrer(P.uadd, P.usub, nargs=1)
+@type_inferrer(P.scalar_uadd, P.scalar_usub, nargs=1)
 async def infer_type_arith_unary(track, x):
     """Infer the return type of a unary arithmetic operator."""
     t = await x['type']
@@ -201,7 +201,8 @@ async def infer_type_arith_unary(track, x):
     return t
 
 
-@type_inferrer(P.add, P.sub, P.mul, P.div, P.mod, P.pow, nargs=2)
+@type_inferrer(P.scalar_add, P.scalar_sub, P.scalar_mul, P.scalar_div,
+               P.scalar_mod, P.scalar_pow, nargs=2)
 async def infer_type_arith_bin(track, x, y):
     """Infer the return type of a binary arithmetic operator."""
     t = await track.assert_same(x, y)

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -218,9 +218,9 @@ async def infer_type_shape(track, ary):
     return Tuple([UInt(64)]*len(shp))
 
 
-@type_inferrer(P.map_array, nargs=2)
-async def infer_type_map_array(track, fn, ary):
-    """Infer the return type of map_array."""
+@type_inferrer(P.array_map, nargs=2)
+async def infer_type_array_map(track, fn, ary):
+    """Infer the return type of array_map."""
     fn_t = await fn['type']
     ary_t = await ary['type']
     if not isinstance(ary_t, Array):
@@ -229,9 +229,9 @@ async def infer_type_map_array(track, fn, ary):
     return Array(await fn_t(xref))
 
 
-@type_inferrer(P.scan_array, P.reduce_array, nargs=4)
+@type_inferrer(P.array_scan, P.array_reduce, nargs=4)
 async def infer_type_across_array(track, fn, init, ary, ax):
-    """Infer the return type of scan/reduce_array."""
+    """Infer the return type of scan/array_reduce."""
     fn_t = await fn['type']
     ary_t = await ary['type']
     init_t = await init['type']
@@ -286,13 +286,13 @@ async def infer_type_return_(track, x):
     return await x['type']
 
 
-@type_inferrer(P.maplist, nargs=2)
-async def infer_type_maplist(track, f, xs):
-    """Infer the return type of maplist."""
+@type_inferrer(P.list_map, nargs=2)
+async def infer_type_list_map(track, f, xs):
+    """Infer the return type of list_map."""
     f_t = await f['type']
     xs_t = await xs['type']
     if not isinstance(xs_t, List):
-        raise MyiaTypeError('Expect list for maplist')
+        raise MyiaTypeError('Expect list for list_map')
     xref = track.engine.vref(dict(type=xs_t.element_type))
     ret_t = await f_t(xref)
     return List(ret_t)

--- a/tests/ir/test_clone.py
+++ b/tests/ir/test_clone.py
@@ -38,7 +38,7 @@ def test_clone_simple():
 
     common = d1 & d2
     assert all(is_constant(x) for x in common)
-    assert {x.value for x in common} == {P.add, P.mul, P.return_}
+    assert {x.value for x in common} == {P.scalar_add, P.scalar_mul, P.return_}
 
 
 def test_clone_closure():

--- a/tests/ir/test_ir_utils.py
+++ b/tests/ir/test_ir_utils.py
@@ -78,18 +78,18 @@ def test_dfs_variants():
     inner_ret = inner_graph.return_
 
     deep = _name_nodes(_dfs(inner_ret, succ_deep))
-    assert deep == set('return add y z mul x'.split())
+    assert deep == set('return scalar_add y z scalar_mul x'.split())
 
     deeper = _name_nodes(_dfs(inner_ret, succ_deeper))
-    assert deeper == set('return add y z mul x w 3 q g'.split())
+    assert deeper == set('return scalar_add y z scalar_mul x w 3 q g'.split())
 
     _bound_fv = freevars_boundary(inner_graph, True)
     bound_fv = _name_nodes(_dfs(inner_ret, succ_deeper, _bound_fv))
-    assert bound_fv == set('return add y z'.split())
+    assert bound_fv == set('return scalar_add y z'.split())
 
     _no_fv = freevars_boundary(inner_graph, False)
     no_fv = _name_nodes(_dfs(inner_ret, succ_deeper, _no_fv))
-    assert no_fv == set('return add y'.split())
+    assert no_fv == set('return scalar_add y'.split())
 
     _excl_root = exclude_from_set([inner_ret])
     excl_root = _name_nodes(_dfs(inner_ret, succ_deeper, _excl_root))

--- a/tests/opt/test_lib.py
+++ b/tests/opt/test_lib.py
@@ -4,7 +4,7 @@ from pytest import mark
 from .test_opt import _check_opt
 from myia.opt import lib
 from myia.prim.py_implementations import \
-    head, tail, setitem, add, mul
+    head, tail, setitem, scalar_add, scalar_mul
 
 
 #######################
@@ -515,9 +515,9 @@ def test_drop_into_if():
 
     def before_helper(x):
         if x < 0:
-            return mul
+            return scalar_mul
         else:
-            return add
+            return scalar_add
 
     def before(x, y, z):
         return before_helper(x)(y, z)

--- a/tests/opt/test_opt.py
+++ b/tests/opt/test_opt.py
@@ -44,25 +44,25 @@ QP_to_QR = psub(
 )
 
 multiply_by_zero_l = psub(
-    (prim.mul, 0, X),
+    (prim.scalar_mul, 0, X),
     0,
     name='multiply_by_zero_l'
 )
 
 multiply_by_zero_r = psub(
-    (prim.mul, X, 0),
+    (prim.scalar_mul, X, 0),
     0,
     name='multiply_by_zero_r'
 )
 
 add_zero_l = psub(
-    (prim.add, 0, X),
+    (prim.scalar_add, 0, X),
     X,
     name='add_zero_l'
 )
 
 add_zero_r = psub(
-    (prim.add, X, 0),
+    (prim.scalar_add, X, 0),
     X,
     name='add_zero_r'
 )
@@ -98,7 +98,7 @@ def test_sexp_conversion():
     def f():
         return 10 * (5 + 4)
 
-    sexp = (prim.mul, 10, (prim.add, 5, Constant(4)))
+    sexp = (prim.scalar_mul, 10, (prim.scalar_add, 5, Constant(4)))
 
     g = sexp_to_graph(sexp)
 

--- a/tests/prim/test_py_implementations.py
+++ b/tests/prim/test_py_implementations.py
@@ -6,7 +6,7 @@ import numpy as np
 from myia.dtype import Int, Float, List, Tuple, External
 from myia.prim.py_implementations import head, setattr as myia_setattr, \
     setitem as myia_setitem, tail, hastype, typeof, \
-    shape, reshape, map_array, scan_array, reduce_array, distribute, dot, \
+    shape, reshape, array_map, array_scan, array_reduce, distribute, dot, \
     partial as myia_partial, _assert_scalar
 
 from ..test_lang import parse_compare
@@ -152,39 +152,39 @@ def test_prim_shape():
     assert shape(v) == (2, 3)
 
 
-def test_prim_map_array():
+def test_prim_array_map():
     v = np.zeros((2, 3))
 
     def f(a):
         return a + 1
 
-    v2 = map_array(f, v)
+    v2 = array_map(f, v)
 
     assert (v == 0).all()
     assert (v2 == 1).all()
 
 
-def test_prim_scan_array():
+def test_prim_array_scan():
     v = np.ones((2, 3))
 
     def f(a, b):
         return a + b
 
     vref = np.cumsum(v, axis=1)
-    v2 = scan_array(f, 0, v, 1)
+    v2 = array_scan(f, 0, v, 1)
 
     assert (v == 1).all()
     assert (v2 == vref).all()
 
 
-def test_prim_reduce_array():
+def test_prim_array_reduce():
     v = np.ones((2, 3))
 
     def f(a, b):
         return a + b
 
     vref = np.add.reduce(v, axis=1)
-    v2 = reduce_array(f, 0, v, 1)
+    v2 = array_reduce(f, 0, v, 1)
 
     assert (v == 1).all()
     assert (v2 == vref).all()

--- a/tests/prim/test_py_implementations.py
+++ b/tests/prim/test_py_implementations.py
@@ -7,7 +7,7 @@ from myia.dtype import Int, Float, List, Tuple, External
 from myia.prim.py_implementations import head, setattr as myia_setattr, \
     setitem as myia_setitem, tail, hastype, typeof, \
     shape, reshape, map_array, scan_array, reduce_array, distribute, dot, \
-    partial as myia_partial
+    partial as myia_partial, _assert_scalar
 
 from ..test_lang import parse_compare
 
@@ -82,8 +82,8 @@ def test_prim_ge(x, y):
     return x >= y
 
 
-@parse_compare((2, 7), (4, -6))
-def test_prim_not_(x, y):
+@parse_compare((True,), (False,))
+def test_prim_not_(x):
     return not x
 
 
@@ -215,3 +215,15 @@ def test_prim_partial(x):
 
     g = myia_partial(f, 2)
     return g(x)
+
+
+def test_assert_scalar():
+    _assert_scalar(0)
+    _assert_scalar(1.0, 2.0)
+    _assert_scalar(np.ones(()))
+    # with pytest.raises(TypeError):
+    #     _assert_scalar(1, 1.0)
+    with pytest.raises(TypeError):
+        _assert_scalar(np.ones((2, 2)))
+    with pytest.raises(TypeError):
+        _assert_scalar((1, 2), (3, 4))

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -13,9 +13,9 @@ from myia.dtype import Array as A, Bool, Int, Float, Tuple as T, List as L, \
     Type, UInt, External
 from myia.prim import Primitive
 from myia.prim.py_implementations import \
-    scalar_add, scalar_mul, scalar_lt, head, tail, maplist, hastype, \
-    typeof, scalar_usub, dot, distribute, shape, map_array, scan_array, \
-    reduce_array, reshape, partial as myia_partial
+    scalar_add, scalar_mul, scalar_lt, head, tail, list_map, hastype, \
+    typeof, scalar_usub, dot, distribute, shape, array_map, array_scan, \
+    array_reduce, reshape, partial as myia_partial
 
 
 B = Bool()
@@ -757,12 +757,12 @@ def test_cover_limitedvalue_eq(x, y):
         (li64, f64, InferenceError),
     ]
 )
-def test_maplist(xs, ys):
+def test_list_map(xs, ys):
 
     def square(x):
         return x * x
 
-    return maplist(square, xs), maplist(square, ys)
+    return list_map(square, xs), list_map(square, ys)
 
 
 @infer(
@@ -839,7 +839,7 @@ def test_map_2(xs, z):
             return x + y
         return f
 
-    return maplist(adder(z), xs)
+    return list_map(adder(z), xs)
 
 
 def _square(x):
@@ -1013,10 +1013,10 @@ def test_reshape(v, shp):
 @infer(shape=[({'type': af32, 'shape': (3, 4)}, (3, 4))],
        type=[({'type': ai64, 'shape': (3, 4)}, ai64),
              ({'type': i64}, InferenceError)])
-def test_map_array(ary):
+def test_array_map(ary):
     def f(v):
         return v + 1
-    return map_array(f, ary)
+    return array_map(f, ary)
 
 
 @infer(shape=[({'type': ai64, 'shape': (3, 4)}, {'value': 1}, (3, 4))],
@@ -1027,18 +1027,18 @@ def test_map_array(ary):
             InferenceError),
            ({'type': ai64, 'shape': (3, 4)}, {'value': 1}, InferenceError)
        ])
-def test_scan_array(ary, ax):
+def test_array_scan(ary, ax):
     def f(a, b):
         return a + b
-    return scan_array(f, 0, ary, ax)
+    return array_scan(f, 0, ary, ax)
 
 
 @infer(shape=[({'type': ai64, 'shape': (3, 4)}, {'value': 1}, (3,)),
               ({'type': ai64, 'shape': (3, 4)}, {'type': u64}, (ANYTHING,))])
-def test_reduce_array(ary, ax):
+def test_array_reduce(ary, ax):
     def f(a, b):
         return a + b
-    return reduce_array(f, 0, ary, ax)
+    return array_reduce(f, 0, ary, ax)
 
 
 @infer(type=[(i64, i64)],

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -13,9 +13,9 @@ from myia.dtype import Array as A, Bool, Int, Float, Tuple as T, List as L, \
     Type, UInt, External
 from myia.prim import Primitive
 from myia.prim.py_implementations import \
-    add, mul, lt, head, tail, maplist, hastype, typeof, usub, \
-    dot, distribute, shape, map_array, scan_array, reduce_array, reshape, \
-    partial as myia_partial
+    scalar_add, scalar_mul, scalar_lt, head, tail, maplist, hastype, \
+    typeof, scalar_usub, dot, distribute, shape, map_array, scan_array, \
+    reduce_array, reshape, partial as myia_partial
 
 
 B = Bool()
@@ -292,19 +292,19 @@ def test_nullary_closure(x, y):
 @infer(type=(i64, f64, T(i64, f64)))
 def test_merge_point(x, y):
     def mul2():
-        return mul
+        return scalar_mul
     m = mul2()
     return m(x, x), m(y, y)
 
 
 @infer(type=[(i64, InferenceError)])
 def test_not_enough_args_prim(x):
-    return mul(x)
+    return scalar_mul(x)
 
 
 @infer(type=[(i64, i64, i64, InferenceError)])
 def test_too_many_args_prim(x, y, z):
-    return mul(x, y, z)
+    return scalar_mul(x, y, z)
 
 
 @infer(type=[(i64, InferenceError)])
@@ -443,9 +443,9 @@ def test_choose_prim(i, x, y):
 
     def choose(i):
         if i == 0:
-            return add
+            return scalar_add
         else:
-            return mul
+            return scalar_mul
 
     return choose(i)(x, y)
 
@@ -461,9 +461,9 @@ def test_choose_prim_incompatible(i, x, y):
 
     def choose(i):
         if i == 0:
-            return add
+            return scalar_add
         else:
-            return lt
+            return scalar_lt
 
     return choose(i)(x, y)
 
@@ -652,7 +652,7 @@ def test_hof_5(c1, c2, x, y):
 
     def pick_f(c):
         if c:
-            return usub
+            return scalar_usub
         else:
             return _to_i64
 

--- a/tests/test_specialize.py
+++ b/tests/test_specialize.py
@@ -8,7 +8,7 @@ from myia.graph_utils import dfs
 from myia.infer import Inferrer
 from myia.ir import succ_deeper, is_apply, is_constant
 from myia.prim import ops as P, Primitive
-from myia.prim.py_implementations import typeof, hastype, maplist, scalar_add
+from myia.prim.py_implementations import typeof, hastype, list_map, scalar_add
 from myia.specialize import DEAD
 
 from .test_infer import i64, f64
@@ -29,7 +29,7 @@ op_whitelist = [
     P.return_, P.if_, P.partial,
     P.scalar_add, P.scalar_mul, P.scalar_sub,
     P.scalar_gt, P.scalar_lt,
-    P.cons_tuple, P.hastype, P.maplist
+    P.cons_tuple, P.hastype, P.list_map
 ]
 
 
@@ -181,24 +181,24 @@ def test_hastype(x, y):
 
 
 @specialize(([fp1, fp2],))
-def test_maplist(xs):
+def test_list_map(xs):
     def square(x):
         return x * x
 
-    return maplist(square, xs)
+    return list_map(square, xs)
 
 
 @specialize(([fp1, fp2], [int1, int2]))
-def test_maplist_polymorphic(xs, ys):
+def test_list_map_polymorphic(xs, ys):
     def square(x):
         return x * x
 
-    return maplist(square, xs), maplist(square, ys)
+    return list_map(square, xs), list_map(square, ys)
 
 
 @mark.xfail(reason="Cannot specialize f")
 @specialize((True, [fp1, fp2], [int1, int2]))
-def test_maplist_polymorphic_2(c, xs, ys):
+def test_list_map_polymorphic_2(c, xs, ys):
     def square(x):
         return x * x
 
@@ -210,7 +210,7 @@ def test_maplist_polymorphic_2(c, xs, ys):
     else:
         f = double
 
-    return maplist(f, xs), maplist(f, ys)
+    return list_map(f, xs), list_map(f, ys)
 
 
 @specialize((int1, int2))

--- a/tests/test_specialize.py
+++ b/tests/test_specialize.py
@@ -8,7 +8,7 @@ from myia.graph_utils import dfs
 from myia.infer import Inferrer
 from myia.ir import succ_deeper, is_apply, is_constant
 from myia.prim import ops as P, Primitive
-from myia.prim.py_implementations import typeof, hastype, maplist, add
+from myia.prim.py_implementations import typeof, hastype, maplist, scalar_add
 from myia.specialize import DEAD
 
 from .test_infer import i64, f64
@@ -27,8 +27,8 @@ specialize_pipeline = standard_pipeline.select(
 # to eliminate at this stage.
 op_whitelist = [
     P.return_, P.if_, P.partial,
-    P.add, P.mul, P.sub,
-    P.gt, P.lt,
+    P.scalar_add, P.scalar_mul, P.scalar_sub,
+    P.scalar_gt, P.scalar_lt,
     P.cons_tuple, P.hastype, P.maplist
 ]
 
@@ -234,7 +234,7 @@ def test_unused_function_parameter(x):
 @specialize((int1,))
 def test_indirect_primitive(x):
     def add2():
-        return add
+        return scalar_add
 
     return add2()(x, x)
 

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from myia.api import compile
 from myia.prim.py_implementations import (map_array, maplist, reduce_array,
-                                          scan_array, usub)
+                                          scan_array, scalar_usub)
 
 from .test_lang import parse_compare
 
@@ -17,7 +17,7 @@ def test_vm_icall_fn(l):
 
 @parse_compare(([1, 2, 3],))
 def test_vm_icall_prim(l):
-    return maplist(usub, l)
+    return maplist(scalar_usub, l)
 
 
 @parse_compare(([1, 2, 3],))

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -1,8 +1,8 @@
 import numpy as np
 
 from myia.api import compile
-from myia.prim.py_implementations import (map_array, maplist, reduce_array,
-                                          scan_array, scalar_usub)
+from myia.prim.py_implementations import (array_map, list_map, array_reduce,
+                                          array_scan, scalar_usub)
 
 from .test_lang import parse_compare
 
@@ -12,12 +12,12 @@ def test_vm_icall_fn(l):
     def square(x):
         return x * x
 
-    return maplist(square, l)
+    return list_map(square, l)
 
 
 @parse_compare(([1, 2, 3],))
 def test_vm_icall_prim(l):
-    return maplist(scalar_usub, l)
+    return list_map(scalar_usub, l)
 
 
 @parse_compare(([1, 2, 3],))
@@ -27,42 +27,42 @@ def test_vm_icall_clos(l):
     def add2(v):
         return v + y
 
-    return maplist(add2, l)
+    return list_map(add2, l)
 
 
-def test_vm_map_array():
+def test_vm_array_map():
     @compile
     def f(x):
         def add1(x):
             return x + 1
 
-        return map_array(add1, x)
+        return array_map(add1, x)
 
     a = np.zeros((2, 3))
     res = f(a)
     assert (res == np.ones((2, 3))).all()
 
 
-def test_vm_scan_array():
+def test_vm_array_scan():
     @compile
     def f(x):
         def add(x, y):
             return x + y
 
-        return scan_array(add, 0, x, 1)
+        return array_scan(add, 0, x, 1)
 
     a = np.ones((2, 3))
     res = f(a)
     assert (res == a.cumsum(axis=1)).all()
 
 
-def test_vm_reduce_array():
+def test_vm_array_reduce():
     @compile
     def f(x):
         def add(x, y):
             return x + y
 
-        return reduce_array(add, 0, x, 0)
+        return array_reduce(add, 0, x, 0)
 
     a = np.ones((2, 3))
     res = f(a)


### PR DESCRIPTION
* Rename `add`, etc. to `scalar_add`, etc.
* Standardize on `<type>_<name>`, so e.g. `list_map` and `array_reduce`.
