### PR TITLE
New primitives: identity, bool_and, bool_or, switch

### DIFF
--- a/myia/api.py
+++ b/myia/api.py
@@ -35,6 +35,8 @@ default_object_map = {
     operator.pos: P.scalar_uadd,
     operator.neg: P.scalar_usub,
     operator.not_: P.bool_not,
+    operator.and_: P.bool_and,
+    operator.or_: P.bool_or,
     operator.getitem: P.getitem,
     operator.setitem: P.setitem,
     getattr: P.getattr,

--- a/myia/infer.py
+++ b/myia/infer.py
@@ -363,6 +363,10 @@ class Reference:
     def __getitem__(self, track):
         return self.engine.get(track, self)
 
+    def get_raw(self, track):
+        """Get the raw value for the track, which might be wrapped."""
+        return self.engine.get_raw(track, self)
+
     def __eq__(self, other):
         return isinstance(other, Reference) \
             and self.node is other.node \

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -161,6 +161,12 @@ add_zero_r = psub(
     name='add_zero_r'
 )
 
+elim_identity = psub(
+    pattern=(P.identity, X),
+    replacement=X,
+    name='elim_identity'
+)
+
 
 ######################
 # Branch elimination #

--- a/myia/prim/ops.py
+++ b/myia/prim/ops.py
@@ -100,6 +100,7 @@ dot = Primitive('dot')
 
 
 if_ = Primitive('if')
+switch = Primitive('switch')
 return_ = Primitive('return')
 
 

--- a/myia/prim/ops.py
+++ b/myia/prim/ops.py
@@ -106,5 +106,6 @@ return_ = Primitive('return')
 #################
 
 list_map = Primitive('list_map')
+identity = Primitive('identity')
 resolve = Primitive('resolve')
 partial = Primitive('partial')

--- a/myia/prim/ops.py
+++ b/myia/prim/ops.py
@@ -43,6 +43,8 @@ scalar_ne = Primitive('scalar_ne')
 scalar_le = Primitive('scalar_le')
 scalar_ge = Primitive('scalar_ge')
 bool_not = Primitive('bool_not')
+bool_and = Primitive('bool_and')
+bool_or = Primitive('bool_or')
 
 
 ######################

--- a/myia/prim/py_implementations.py
+++ b/myia/prim/py_implementations.py
@@ -346,6 +346,12 @@ def _list_map_vm(vm, f, xs):
     return list(map(f_, xs))
 
 
+@register(primops.identity)
+def identity(x):
+    """Implement `identity`."""
+    return x
+
+
 @vm_register(primops.resolve)
 def _resolve_vm(vm, data, item):
     """Implement `resolve` for the VM."""

--- a/myia/prim/py_implementations.py
+++ b/myia/prim/py_implementations.py
@@ -146,6 +146,22 @@ def bool_not(x):
     return not x
 
 
+@register(primops.bool_and)
+def bool_and(x, y):
+    """Implement `bool_and`."""
+    assert x is True or x is False
+    assert y is True or y is False
+    return x and y
+
+
+@register(primops.bool_or)
+def bool_or(x, y):
+    """Implement `bool_or`."""
+    assert x is True or x is False
+    assert y is True or y is False
+    return x or y
+
+
 @register(primops.typeof)
 def typeof(x):
     """Implement typeof."""

--- a/myia/prim/py_implementations.py
+++ b/myia/prim/py_implementations.py
@@ -402,3 +402,9 @@ def _next(it):
     """Implement `next`."""
     n, data = it
     return (data[n], (n + 1, data))
+
+
+@register(primops.switch)
+def switch(c, x, y):
+    """Implement `switch`."""
+    return x if c else y

--- a/myia/prim/shape_inferrers.py
+++ b/myia/prim/shape_inferrers.py
@@ -179,3 +179,9 @@ async def infer_shape_resolve(track, data, item):
 async def infer_shape_getattr(track, data, item):
     """Infer the shape of getattr."""
     return await static_getter(track, data, item, getattr)
+
+
+@shape_inferrer(P.identity, nargs=1)
+async def infer_shape_identity(track, x):
+    """Infer the shape of identity."""
+    return await x['shape']

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -298,6 +298,12 @@ async def infer_type_list_map(track, f, xs):
     return List(ret_t)
 
 
+@type_inferrer(P.identity, nargs=1)
+async def infer_type_identity(track, x):
+    """Infer the return type of identity."""
+    return await x['type']
+
+
 @type_inferrer(P.resolve, nargs=2)
 async def infer_type_resolve(track, data, item):
     """Infer the return type of resolve."""

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -168,11 +168,31 @@ async def infer_type_hastype(track, x, t):
 
 
 @type_inferrer(P.bool_not, nargs=1)
-async def infer_type_not(track, x):
+async def infer_type_bool_not(track, x):
     """Infer the return type of not."""
     x_t = await x['type']
     if x_t != Bool():
         raise MyiaTypeError('Expected Bool for not.')
+    return Bool()
+
+
+@type_inferrer(P.bool_and, nargs=2)
+async def infer_type_bool_and(track, x, y):
+    """Infer the return type of bool_and."""
+    x_t = await x['type']
+    y_t = await y['type']
+    if x_t != Bool() or y_t != Bool():
+        raise MyiaTypeError('Expected Bool for bool_and.')
+    return Bool()
+
+
+@type_inferrer(P.bool_or, nargs=2)
+async def infer_type_bool_or(track, x, y):
+    """Infer the return type of bool_or."""
+    x_t = await x['type']
+    y_t = await y['type']
+    if x_t != Bool() or y_t != Bool():
+        raise MyiaTypeError('Expected Bool for bool_or.')
     return Bool()
 
 

--- a/myia/prim/value_inferrers.py
+++ b/myia/prim/value_inferrers.py
@@ -167,6 +167,20 @@ async def infer_value_if(engine, cond, tb, fb):
     return await fn()
 
 
+@value_inferrer(P.switch, nargs=3)
+async def infer_value_switch(track, cond, tb, fb):
+    """Infer the return type of switch."""
+    v = await cond['value']
+    if v is True:
+        return await tb.get_raw('value')
+    elif v is False:
+        return await fb.get_raw('value')
+    elif v is ANYTHING:
+        # Note: we do not infer the values for the branches at all.
+        # If we did, we may encounter recursion and deadlock.
+        return ANYTHING
+
+
 @value_inferrer(P.partial, nargs=None)
 async def infer_value_partial(engine, fn, *args):
     """Infer the return type of partial."""

--- a/tests/opt/test_lib.py
+++ b/tests/opt/test_lib.py
@@ -4,7 +4,7 @@ from pytest import mark
 from .test_opt import _check_opt
 from myia.opt import lib
 from myia.prim.py_implementations import \
-    head, tail, setitem, scalar_add, scalar_mul
+    head, tail, setitem, scalar_add, scalar_mul, identity
 
 
 #######################
@@ -188,6 +188,17 @@ def test_add_zero():
     _check_opt(before2, after,
                lib.add_zero_l,
                lib.add_zero_r)
+
+
+def test_elim_identity():
+
+    def before(x, y):
+        return identity(x) + identity(y)
+
+    def after(x, y):
+        return x + y
+
+    _check_opt(before, after, lib.elim_identity)
 
 
 ######################

--- a/tests/prim/test_py_implementations.py
+++ b/tests/prim/test_py_implementations.py
@@ -7,7 +7,7 @@ from myia.dtype import Int, Float, List, Tuple, External
 from myia.prim.py_implementations import head, setattr as myia_setattr, \
     setitem as myia_setitem, tail, hastype, typeof, \
     shape, reshape, array_map, array_scan, array_reduce, distribute, dot, \
-    partial as myia_partial, _assert_scalar
+    partial as myia_partial, identity, _assert_scalar
 
 from ..test_lang import parse_compare
 
@@ -227,3 +227,8 @@ def test_assert_scalar():
         _assert_scalar(np.ones((2, 2)))
     with pytest.raises(TypeError):
         _assert_scalar((1, 2), (3, 4))
+
+
+def test_prim_identity():
+    for x in (1, 1.7, True, False, [1, 2, 3], (4, 5)):
+        assert identity(x) is x

--- a/tests/prim/test_py_implementations.py
+++ b/tests/prim/test_py_implementations.py
@@ -7,7 +7,7 @@ from myia.dtype import Int, Float, List, Tuple, External
 from myia.prim.py_implementations import head, setattr as myia_setattr, \
     setitem as myia_setitem, tail, hastype, typeof, \
     shape, reshape, array_map, array_scan, array_reduce, distribute, dot, \
-    partial as myia_partial, identity, _assert_scalar
+    partial as myia_partial, identity, _assert_scalar, switch
 
 from ..test_lang import parse_compare
 
@@ -232,3 +232,8 @@ def test_assert_scalar():
 def test_prim_identity():
     for x in (1, 1.7, True, False, [1, 2, 3], (4, 5)):
         assert identity(x) is x
+
+
+def test_prim_switch():
+    assert switch(True, 1, 2) == 1
+    assert switch(False, 1, 2) == 2

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -15,7 +15,8 @@ from myia.prim import Primitive
 from myia.prim.py_implementations import \
     scalar_add, scalar_mul, scalar_lt, head, tail, list_map, hastype, \
     typeof, scalar_usub, dot, distribute, shape, array_map, array_scan, \
-    array_reduce, reshape, partial as myia_partial, identity, bool_and, bool_or
+    array_reduce, reshape, partial as myia_partial, identity, \
+    bool_and, bool_or, switch
 
 
 B = Bool()
@@ -1084,3 +1085,42 @@ def test_bool_and(x, y):
              (B, i64, InferenceError)])
 def test_bool_or(x, y):
     return bool_or(x, y)
+
+
+@infer(
+    type=[
+        (B, i64, i64, i64),
+        (i64, i64, i64, InferenceError),
+        (B, i64, f64, InferenceError),
+        ({'value': True}, i64, f64, i64),
+        ({'value': False}, i64, f64, f64),
+    ],
+    value=[
+        (True, 1, 2, 1),
+        (False, 1, 2, 2),
+        (ANYTHING, 1, 2, ANYTHING),
+    ],
+    shape=[
+        ({'type': B},
+         {'type': ai64, 'shape': (6, 13)},
+         {'type': ai64, 'shape': (6, 13)},
+         (6, 13)),
+
+        ({'type': B},
+         {'type': ai64, 'shape': (6, 13)},
+         {'type': ai64, 'shape': (6, 14)},
+         InferenceError),
+
+        ({'type': B, 'value': True},
+         {'type': ai64, 'shape': (6, 13)},
+         {'type': ai64, 'shape': (6, 14)},
+         (6, 13)),
+
+        ({'type': B, 'value': False},
+         {'type': ai64, 'shape': (6, 13)},
+         {'type': ai64, 'shape': (6, 14)},
+         (6, 14)),
+    ]
+)
+def test_switch(c, x, y):
+    return switch(c, x, y)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -15,7 +15,7 @@ from myia.prim import Primitive
 from myia.prim.py_implementations import \
     scalar_add, scalar_mul, scalar_lt, head, tail, list_map, hastype, \
     typeof, scalar_usub, dot, distribute, shape, array_map, array_scan, \
-    array_reduce, reshape, partial as myia_partial, identity
+    array_reduce, reshape, partial as myia_partial, identity, bool_and, bool_or
 
 
 B = Bool()
@@ -1070,3 +1070,17 @@ def test_partial_2(x):
        shape=[({'type': ai64, 'shape': (6, 13)}, (6, 13))])
 def test_identity(x):
     return identity(x)
+
+
+@infer(type=[(B, B, B),
+             (i64, B, InferenceError),
+             (B, i64, InferenceError)])
+def test_bool_and(x, y):
+    return bool_and(x, y)
+
+
+@infer(type=[(B, B, B),
+             (i64, B, InferenceError),
+             (B, i64, InferenceError)])
+def test_bool_or(x, y):
+    return bool_or(x, y)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -15,7 +15,7 @@ from myia.prim import Primitive
 from myia.prim.py_implementations import \
     scalar_add, scalar_mul, scalar_lt, head, tail, list_map, hastype, \
     typeof, scalar_usub, dot, distribute, shape, array_map, array_scan, \
-    array_reduce, reshape, partial as myia_partial
+    array_reduce, reshape, partial as myia_partial, identity
 
 
 B = Bool()
@@ -1064,3 +1064,9 @@ def test_partial_2(x):
         else:
             return f3
     return g(x < 42)(x)
+
+
+@infer(type=[(i64, i64)],
+       shape=[({'type': ai64, 'shape': (6, 13)}, (6, 13))])
+def test_identity(x):
+    return identity(x)

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -230,6 +230,16 @@ def test_or(x, y):
     return x > 0 or y > 0
 
 
+@parse_compare((7, 3), (-1, 3), (-3, 1), (-1, -1))
+def test_band(x, y):
+    return (x > 0) & (y > 0)
+
+
+@parse_compare((7, 3), (-1, 3), (-3, 1), (-1, -1))
+def test_bor(x, y):
+    return (x > 0) | (y > 0)
+
+
 ###################
 # while statement #
 ###################


### PR DESCRIPTION
This adds the following primitives:

* `identity`, the identity function.
* `bool_and`, which implements `a & b` on booleans
* `bool_or`, which implements `a | b` on booleans
* `switch`, which is an eager version of `if` (`switch(a, b, c) == b if a else c` when `b` and `c` are atoms, or alternatively, it is equivalent to `[c, b][a]`)
* The `elim_identity` optimization. self-explanatory.

These primitives allow us to write some conditional/boolean code without creating unnecessary graphs, which will be less taxing on the inferrer and optimizer. They will be used by an upcoming PR.

Note: this is based on the commits in #93.