### PR TITLE
Reorganize inference, variables in inference, display error tracebacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
+dist: xenial
+sudo: true
 python:
-  - 3.6
+  - 3.7
 install:
   - pip install -r requirements.txt
   - pip install -e . --no-deps

--- a/myia/api.py
+++ b/myia/api.py
@@ -38,6 +38,7 @@ scalar_object_map = {
     operator.not_: P.bool_not,
     operator.and_: P.bool_and,
     operator.or_: P.bool_or,
+    operator.matmul: P.dot,
     operator.getitem: P.getitem,
     operator.setitem: P.setitem,
     bool: P.identity,
@@ -64,6 +65,7 @@ standard_object_map = {
     operator.not_: C.not_,
     operator.and_: C.and_,
     operator.or_: C.or_,
+    operator.matmul: C.matmul,
     operator.getitem: P.getitem,
     operator.setitem: P.setitem,
     bool: C.bool,
@@ -129,6 +131,7 @@ standard_method_map = TypeMap({
         '__gt__': C.array_gt,
         '__le__': C.array_le,
         '__ge__': C.array_ge,
+        '__matmul__': P.dot,
     }
 })
 

--- a/myia/api.py
+++ b/myia/api.py
@@ -282,6 +282,13 @@ class Inferrer(PipelineStep):
             required_tracks=self.required_tracks,
         )
 
+        for arg in argspec:
+            if 'value' in arg:
+                v = arg['value']
+                for track_name, track in engine.tracks.items():
+                    if track_name not in arg or track_name == 'value':
+                        arg[track_name] = track.from_value(v, None)
+
         try:
             res, context = engine.run(graph, argspec)
             return {'inference_results': res,

--- a/myia/composite.py
+++ b/myia/composite.py
@@ -160,6 +160,12 @@ def or_(x, y):
     return x.__or__(y)
 
 
+@core
+def matmul(x, y):
+    """Implementation of `matmul` (`@`)."""
+    return x.__matmul__(y)
+
+
 ##################
 # Scalar methods #
 ##################

--- a/myia/debug/label.py
+++ b/myia/debug/label.py
@@ -2,7 +2,7 @@
 
 
 from ..info import DebugInfo
-from ..ir.anf import Graph
+from ..ir.anf import ANFNode, Graph
 from ..ir.utils import is_constant, is_constant_graph, is_parameter, is_special
 from ..prim import Primitive
 from ..utils import Named, Namespace
@@ -134,3 +134,13 @@ class NodeLabeler:
 short_labeler = NodeLabeler(
     relation_symbols=short_relation_symbols
 )
+
+
+def label(x):
+    """Return an informative textual label for a node."""
+    if isinstance(x, Primitive):
+        return x.name
+    elif isinstance(x, (ANFNode, Graph, DebugInfo)):
+        return short_labeler.name(x)
+    else:
+        return repr(x)

--- a/myia/debug/traceback.py
+++ b/myia/debug/traceback.py
@@ -2,6 +2,7 @@
 
 import ast
 import sys
+from colorama import init as colorama_init, Fore, Style
 
 from ..infer import Inferrer, InferenceError
 from ..ir import is_apply, is_constant_graph
@@ -39,7 +40,8 @@ def _print_lines(lines, l1, c1, l2, c2, label='', mode='^'):
             prefix = trimmed[:start]
             hl = trimmed[start:end]
             rest = trimmed[end:]
-            eprint(f'  {prefix}\033[1;31m{hl}\033[0m{rest}')
+            eprint(f'  {prefix}{Fore.RED}{Style.BRIGHT}'
+                   f'{hl}{Style.RESET_ALL}{rest}')
 
 
 def _show_location(loc, ctx, label):

--- a/myia/debug/traceback.py
+++ b/myia/debug/traceback.py
@@ -1,0 +1,185 @@
+"""Tools to print a traceback for an error in Myia."""
+
+import ast
+import sys
+
+from ..dtype import Function
+from ..infer import Inferrer, InferenceError
+from ..prim import Primitive
+from ..ir import is_apply, is_constant_graph
+
+from .label import short_labeler as shl
+
+
+def eprint(*things):
+    """Print to stderr."""
+    print(*things, file=sys.stderr)
+
+
+def skip_node(node):
+    """Whether to skip a step in the traceback based on ast node type."""
+    return isinstance(node, (ast.If, ast.While, ast.For))
+
+
+def _print_lines(lines, l1, c1, l2, c2, label='', mode='^'):
+    for ln in range(l1, l2 + 1):
+        line = lines[ln - 1]
+        if ln == l1:
+            trimmed = line.lstrip()
+            to_trim = len(line) - len(trimmed)
+            start = c1 - to_trim
+        else:
+            trimmed = line[to_trim:]
+            start = 0
+
+        if ln == l2:
+            end = c2 - to_trim
+        else:
+            end = len(trimmed)
+
+        if isinstance(mode, str):
+            eprint(f'  {trimmed}')
+            prefix = ' ' * (start + 2)
+            eprint(prefix + '^' * (end - start) + label)
+        else:
+            prefix = trimmed[:start]
+            hl = trimmed[start:end]
+            rest = trimmed[end:]
+            eprint(f'  {prefix}\033[1;31m{hl}\033[0m{rest}')
+
+
+def _show_location(loc, ctx, label):
+    eprint(f'File "{loc.filename}", line {loc.line}, column {loc.column}')
+    eprint(ctx)
+    with open(loc.filename, 'r') as contents:
+        lines = contents.read().split('\n')
+        _print_lines(lines, loc.line, loc.column,
+                     loc.line_end, loc.column_end,
+                     label, mode=5)
+
+
+def _format_context(ctx):
+
+    def fromsig(sig):
+        sig = dict(sig)
+        t = sig['type']
+        shp = sig['shape']
+        if shp:
+            return f'{t}:{shp}'
+        else:
+            return t
+
+    g = ctx.graph
+    if g is None:
+        return '<unknown>'
+    args = [f'{shl.name(p)}: {fromsig(t)}'
+            for (p, t) in zip(g.parameters, ctx.argkey)]
+    return f'{shl.name(g)}({", ".join(args)})'
+
+
+def _best_label(node, typ):
+    if isinstance(typ, Inferrer):
+        return _best_label(typ.identifier, None)
+    elif isinstance(node, Primitive):
+        return node.name
+    else:
+        return shl.name(node)
+
+
+def _find_loc(ref):
+    node = ref.node
+    if is_constant_graph(node):
+        node = node.value
+    loc = node.debug.find('location')
+    if loc is None:
+        eprint('<Missing location for node>')
+        return None
+    return loc
+
+
+async def _myia_multirefs(engine, error, refs):
+    for i, ref in enumerate(refs):
+        loc = _find_loc(ref)
+        if loc is None:
+            continue
+        ctx = ref.context
+        g = ctx.graph
+        while g and g.flags.get('auxiliary') \
+                and ctx.parent and ctx.parent.graph:
+            ctx = ctx.parent
+            g = ctx.graph
+        ctx_str = 'in ' + _format_context(ctx)
+        if g and g.flags.get('core', False):
+            eprint(ctx_str)
+            eprint('  Invalid signature for core function.')
+            eprint()
+            break
+        _show_location(loc, ctx_str, str())
+        eprint()
+
+    eprint(f'{type(error).__qualname__}: {error.message}')
+
+
+async def _myia_traceback(engine, error):
+    refs = [*error.traceback_refs.values()]
+    refs.reverse()
+
+    if not refs:
+        return await _myia_multirefs(engine, error, error.refs)
+
+    ref = None
+    for i, ref in enumerate(refs):
+        loc = _find_loc(ref)
+        if loc is None:
+            continue
+        if skip_node(loc.node):
+            continue
+        ctx = ref.context
+        g = ctx.graph
+        while g.flags.get('auxiliary') and ctx.parent and ctx.parent.graph:
+            ctx = ctx.parent
+            g = ctx.graph
+        ctx_str = 'in ' + _format_context(ctx)
+        if g.flags.get('core', False):
+            eprint(ctx_str)
+            eprint('  Invalid signature for core function.')
+            eprint()
+            break
+        _show_location(loc, ctx_str, str())
+        eprint()
+    else:
+        if ref is not None and is_apply(ref.node):
+            ctx = ref.context
+            irefs = [engine.ref(node, ctx) for node in ref.node.inputs]
+            fn_ref, *_ = irefs
+            fn_type, *arg_types = [await iref['type'] for iref in irefs]
+            fn_str = _best_label(fn_ref.node, fn_type) or '<function>'
+            if isinstance(fn_type, (Function, Inferrer)):
+                types_str = ", ".join(map(str, arg_types))
+                eprint(f'in {fn_str}({types_str})')
+                eprint(f'  Invalid signature for core function.')
+            else:
+                eprint(f'Invalid function type:\n  {fn_str}: {fn_type}')
+            eprint()
+
+    eprint(f'{type(error).__qualname__}: {error.message}')
+
+
+_previous_excepthook = sys.excepthook
+
+
+def print_inference_error(err):
+    """Print an InferenceError's traceback."""
+    eng = err.engine
+    eng.run_coroutine(_myia_traceback(eng, err), throw=True)
+
+
+def myia_excepthook(exc_type, exc_value, tb):
+    """Print out InferenceError specially."""
+    if isinstance(exc_value, InferenceError):
+        print_inference_error(exc_value)
+    else:
+        _previous_excepthook(exc_type, exc_value, tb)
+
+
+sys.excepthook = myia_excepthook

--- a/myia/debug/traceback.py
+++ b/myia/debug/traceback.py
@@ -2,7 +2,7 @@
 
 import ast
 import sys
-from colorama import init as colorama_init, Fore, Style
+from colorama import Fore, Style
 
 from ..infer import Inferrer, InferenceError
 from ..ir import is_apply, is_constant_graph

--- a/myia/debug/traceback.py
+++ b/myia/debug/traceback.py
@@ -122,7 +122,6 @@ async def _myia_multirefs(engine, error, refs):
 
 async def _myia_traceback(engine, error):
     refs = [*error.traceback_refs.values()]
-    refs.reverse()
 
     if not refs:
         return await _myia_multirefs(engine, error, error.refs)
@@ -152,7 +151,11 @@ async def _myia_traceback(engine, error):
             ctx = ref.context
             irefs = [engine.ref(node, ctx) for node in ref.node.inputs]
             fn_ref, *_ = irefs
-            fn_type, *arg_types = [await iref['type'] for iref in irefs]
+            try:
+                fn_type, *arg_types = [await iref['type'] for iref in irefs]
+            except InferenceError:
+                eprint('<Error retrieving types for reference.>')
+                return
             fn_str = _best_label(fn_ref.node, fn_type) or '<function>'
             if isinstance(fn_type, (Function, Inferrer)):
                 types_str = ", ".join(map(str, arg_types))

--- a/myia/infer.py
+++ b/myia/infer.py
@@ -980,6 +980,8 @@ class InferenceEngine:
             fut = asyncio.ensure_future(coro, loop=self.loop)
             self.loop.run_forever()
             self.errors.extend(self.loop.collect_errors())
+            for err in self.errors[errs_before:]:
+                err.engine = self
             if errs_before < len(self.errors):
                 if throw:  # pragma: no cover
                     raise self.errors[-1]

--- a/myia/infer/__init__.py
+++ b/myia/infer/__init__.py
@@ -23,4 +23,5 @@ from .utils import (  # noqa
     MyiaTypeError,
     MyiaShapeError,
     ValueWrapper,
+    unwrap,
 )

--- a/myia/infer/__init__.py
+++ b/myia/infer/__init__.py
@@ -3,6 +3,9 @@
 from .core import (  # noqa
     InferenceLoop,
     EvaluationCache,
+    EquivalenceChecker,
+    InferenceVar,
+    reify,
 )
 
 from .graph_infer import (  # noqa

--- a/myia/infer/__init__.py
+++ b/myia/infer/__init__.py
@@ -1,0 +1,26 @@
+"""Inference engine (types, values, etc.)."""
+
+from .core import (  # noqa
+    InferenceLoop,
+    EvaluationCache,
+)
+
+from .graph_infer import (  # noqa
+    Context,
+    Track,
+    InferenceEngine,
+    Reference,
+    Inferrer,
+    GraphInferrer,
+    PrimitiveInferrer,
+    PartialInferrer,
+    register_inferrer,
+)
+
+from .utils import (  # noqa
+    ANYTHING,
+    InferenceError,
+    MyiaTypeError,
+    MyiaShapeError,
+    ValueWrapper,
+)

--- a/myia/infer/core.py
+++ b/myia/infer/core.py
@@ -201,8 +201,8 @@ class EquivalenceChecker:
             if x.provably_equivalent(y):
                 return
 
-            self._tie_dmaps(x, y, refs,)
-            self._tie_dmaps(y, x, refs, hist=False)
+            self._tie_dmaps(x, y, refs)
+            self._tie_dmaps(y, x, refs)
 
         elif x == y or self.merge(x, y):
             pass

--- a/myia/infer/core.py
+++ b/myia/infer/core.py
@@ -1,0 +1,145 @@
+"""Core of the inference engine (not Myia-specific)."""
+
+import asyncio
+from heapq import heappush, heappop
+
+from .utils import InferenceError
+
+
+class _TodoEntry:
+    def __init__(self, order, handler):
+        self.order = order
+        self.handler = handler
+
+    def __lt__(self, other):
+        return self.order < other.order
+
+
+class InferenceLoop(asyncio.AbstractEventLoop):
+    """EventLoop implementation for use with the inferrer.
+
+    This event loop doesn't allow scheduling tasks and callbacks with
+    `call_later` or `call_at`, which means the `timeout` argument to methods
+    like `wait` will not work. `run_forever` will stop when it has exhausted
+    all work there is to be done. This means `run_until_complete` may finish
+    before it can evaluate the future, which suggests an infinite loop.
+    """
+
+    def __init__(self, debug=False):
+        """Initialize an InferenceLoop."""
+        self._running = False
+        self._todo = []
+        self._debug = debug
+        self._futures = []
+        self._errors = []
+
+    def get_debug(self):
+        """Not entirely sure what this does."""
+        return self._debug
+
+    def run_forever(self):
+        """Run this loop until there is no more work to do."""
+        self._running = True
+        while self._todo and self._running:
+            todo = heappop(self._todo)
+            h = todo.handler
+            if isinstance(h, asyncio.Handle):
+                h._run()
+            else:
+                fut = asyncio.ensure_future(h, loop=self)
+                self._futures.append(fut)
+
+    def is_running(self):
+        """Return whether the loop is running."""
+        return self._running
+
+    def is_closed(self):
+        """Return whether the loop is closed."""
+        return not self.is_running()
+
+    def schedule(self, x, order=0):
+        """Schedule a task with the given priority.
+
+        A smaller value for `order` means higher priority.
+        """
+        heappush(self._todo, _TodoEntry(order, x))
+
+    def collect_errors(self):
+        """Return a collection of all exceptions from all futures."""
+        futs, self._futures = self._futures, []
+        errors, self._errors = self._errors, []
+        for fut in futs:
+            if fut.done():
+                exc = fut.exception()
+            else:
+                exc = InferenceError(
+                    f'Could not run inference to completion.'
+                    ' There might be an infinite loop in the program'
+                    ' which prevents type inference from working.',
+                    refs=[]
+                )
+            if exc is not None:
+                errors.append(exc)
+        return errors
+
+    def call_soon(self, callback, *args, context=None):
+        """Call the given callback as soon as possible."""
+        h = asyncio.Handle(callback, args, self)
+        heappush(self._todo, _TodoEntry(0, h))
+        return h
+
+    def call_later(self, delay, callback, *args, context=None):
+        """Not supported."""
+        raise NotImplementedError(
+            '_InferenceLoop does not allow timeouts or time-based scheduling.'
+        )
+
+    def call_at(self, when, callback, *args, context=None):
+        """Not supported."""
+        raise NotImplementedError(
+            '_InferenceLoop does not allow time-based scheduling.'
+        )
+
+    def create_task(self, coro):
+        """Create a task from the given coroutine."""
+        return asyncio.Task(coro, loop=self)
+
+    def create_future(self):
+        """Create a Future using this loop."""
+        return asyncio.Future(loop=self)
+
+
+class EvaluationCache:
+    """Key/value store where keys are associated to Futures.
+
+    Attributes:
+        cache: The cache.
+        loop: The InferenceLoop for async evaluation.
+        keycalc: An async function that takes a key and returns
+            the value associated to that key.
+    """
+
+    def __init__(self, loop, keycalc):
+        """Initialize an EvaluationCache."""
+        self.cache = {}
+        self.loop = loop
+        self.keycalc = keycalc
+
+    def get(self, key):
+        """Get the future associated to the key."""
+        if key not in self.cache:
+            self.set(key, self.keycalc(key))
+        return self.cache[key]
+
+    def set(self, key, coro):
+        """Associate a key to a coroutine."""
+        self.cache[key] = self.loop.create_task(coro)
+
+    def set_value(self, key, value):
+        """Associate a key to a value.
+
+        This will wrap the value in a Future.
+        """
+        fut = asyncio.Future(loop=self.loop)
+        fut.set_result(value)
+        self.cache[key] = fut

--- a/myia/infer/graph_infer.py
+++ b/myia/infer/graph_infer.py
@@ -4,6 +4,7 @@ import asyncio
 from types import FunctionType
 
 from ..dtype import Type, Function
+from ..debug.label import label
 from ..ir import is_constant, is_constant_graph, is_apply
 from ..utils import Partializable, UNKNOWN
 
@@ -15,8 +16,8 @@ from .utils import ANYTHING, InferenceError, MyiaTypeError, DynamicMap, \
 def type_error_nargs(ident, expected, got):
     """Return a MyiaTypeError for number of arguments mismatch."""
     return MyiaTypeError(
-        f'Wrong number of arguments for {ident}:'
-        f' expected {expected}, got {got}.'
+        f"Wrong number of arguments for '{label(ident)}':"
+        f" expected {expected}, got {got}."
     )
 
 

--- a/myia/infer/utils.py
+++ b/myia/infer/utils.py
@@ -58,10 +58,6 @@ class ValueWrapper:
         return type(other) is type(self) \
             and self.value == other.value
 
-    @property
-    def __unwrapped__(self):
-        return self.value
-
 
 class DynamicMap:
     """Represents a sort of mapping that's constantly updated."""
@@ -95,3 +91,10 @@ class DynamicMap:
         This must be overriden in subclasses.
         """
         raise NotImplementedError()  # pragma: no cover
+
+
+def unwrap(x):
+    """Extract the value if x is a ValueWrapper, return x otherwise."""
+    if isinstance(x, ValueWrapper):
+        x = x.value
+    return x

--- a/myia/infer/utils.py
+++ b/myia/infer/utils.py
@@ -1,7 +1,13 @@
 """Misc utilities for inference."""
 
 
+from contextvars import ContextVar
+
 from ..utils import Named, Event, Partializable
+
+
+infer_trace = ContextVar('infer_trace')
+infer_trace.set({})
 
 
 # Represents an unknown value
@@ -27,7 +33,7 @@ class InferenceError(Exception, Partializable):
         super().__init__(message, refs)
         self.message = message
         self.refs = refs
-        self.traceback_refs = {}
+        self.traceback_refs = infer_trace.get()
         if app is not None:
             self.traceback_refs[app.context] = app
 

--- a/myia/infer/utils.py
+++ b/myia/infer/utils.py
@@ -1,0 +1,63 @@
+"""Misc utilities for inference."""
+
+
+from ..utils import Named
+
+
+# Represents an unknown value
+ANYTHING = Named('ANYTHING')
+
+
+class InferenceError(Exception):
+    """Inference error in a Myia program.
+
+    Attributes:
+        message: The error message.
+        refs: A list of references which are involved in the error,
+            e.g. because they have the wrong type or don't match
+            each other.
+        traceback_refs: A map from a context to the first reference in
+            that context that fails to resolve because of this error.
+            This represents a traceback of sorts.
+
+    """
+
+    def __init__(self, message, refs=[], app=None):
+        """Initialize an InferenceError."""
+        super().__init__(message, refs)
+        self.message = message
+        self.refs = refs
+        self.traceback_refs = {}
+        if app is not None:
+            self.traceback_refs[app.context] = app
+
+
+class MyiaTypeError(InferenceError):
+    """Type error in a Myia program."""
+
+
+class MyiaShapeError(InferenceError):
+    """Shape error in a Myia program."""
+
+
+class ValueWrapper:
+    """Wrapper for an inferred value.
+
+    Values may be wrapped using subclasses of ValueWrapper, associating them
+    with tracking data or metadata.
+    """
+
+    def __init__(self, value):
+        """Initialize a ValueWrapper."""
+        self.value = value
+
+    def __hash__(self):
+        return hash(self.value)
+
+    def __eq__(self, other):
+        return type(other) is type(self) \
+            and self.value == other.value
+
+    @property
+    def __unwrapped__(self):
+        return self.value

--- a/myia/info.py
+++ b/myia/info.py
@@ -121,6 +121,15 @@ class NamedDebugInfo(DebugInfo):
         self.name = f'_{prefix}{self.id}'
         return self.name
 
+    def find(self, prop):
+        """Find a property in self or in self.about.debug."""
+        if hasattr(self, prop):
+            return getattr(self, prop)
+        elif self.about is not None:
+            return self.about.debug.find(prop)
+        else:
+            return None
+
 
 class About:
     """Represent a relationship to an object.

--- a/myia/ir/manager.py
+++ b/myia/ir/manager.py
@@ -319,6 +319,10 @@ class ParentStatistic(NestingStatistic):
                     self[g] = deps.pop()
                 else:
                     next_todo.append((g, deps))
+            if todo == next_todo:
+                # Likely a graph with two deps, neither of which have deps.
+                # It's not entirely clear as of yet what makes that happen.
+                raise AssertionError('Problematic graph dependencies')
             todo = next_todo
 
 

--- a/myia/parser.py
+++ b/myia/parser.py
@@ -691,10 +691,12 @@ class Block:
 
     def force_bool(self, cond):
         """Wrap a condition in a call to bool()."""
-        return self.graph.apply(
+        rval = self.graph.apply(
             self.make_resolve(builtins_ns, 'bool'),
             cond
         )
+        rval.debug.location = cond.debug.location
+        return rval
 
     def read(self, varnum: str) -> ANFNode:
         """Read a variable.

--- a/myia/prim/inferrer_utils.py
+++ b/myia/prim/inferrer_utils.py
@@ -1,7 +1,7 @@
 """Utilities that may leveraged by several inferrers."""
 
 
-from ..infer import InferenceError, PartialInferrer, Context, ANYTHING
+from ..infer import InferenceError, PartialInferrer, Context, ANYTHING, unwrap
 
 
 async def static_getter(track, data, item, fetch, chk=None):
@@ -36,7 +36,7 @@ async def static_getter(track, data, item, fetch, chk=None):
             method = mmap_t[item_v]
             method = track.engine.pipeline.resources.convert(method)
             inferrer = track.from_value(method, Context.empty())
-            inferrer = getattr(inferrer, '__unwrapped__', inferrer)
+            inferrer = unwrap(inferrer)
             return PartialInferrer(
                 track,
                 inferrer,

--- a/myia/prim/shape_inferrers.py
+++ b/myia/prim/shape_inferrers.py
@@ -46,6 +46,10 @@ class ShapeTrack(Track):
         super().__init__(engine, name)
         self.constructors = constructors
 
+    def default(self, values):
+        """Default value for ShapeTrack."""
+        return ()
+
     def from_value(self, v, context):
         """Infer the shape of a constant."""
         if isinstance(v, Primitive):

--- a/myia/prim/shape_inferrers.py
+++ b/myia/prim/shape_inferrers.py
@@ -48,6 +48,10 @@ class ShapeTrack(Track):
 
     def default(self, values):
         """Default value for ShapeTrack."""
+        if isinstance(values['type'], Array):
+            raise Exception(
+                'There is no default value for Arrays on the shape track.'
+            )  # pragma: no cover
         return ()
 
     def from_value(self, v, context):

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -343,9 +343,13 @@ async def infer_type_resolve(track, data, item):
     """Infer the return type of resolve."""
     def chk(data_v, item_v):
         if not isinstance(data_v, Namespace):  # pragma: no cover
-            raise MyiaTypeError('data argument to resolve must be Namespace.')
+            raise MyiaTypeError(
+                f'data argument to resolve must be Namespace, not {data_v}'
+            )
         if not isinstance(item_v, str):  # pragma: no cover
-            raise MyiaTypeError('item argument to resolve must be string.')
+            raise MyiaTypeError(
+                f'item argument to resolve must be a string, not {item_v}.'
+            )
     return await static_getter(track, data, item, (lambda x, y: x[y]), chk)
 
 
@@ -354,7 +358,9 @@ async def infer_type_getattr(track, data, item):
     """Infer the return type of getattr."""
     def chk(data_v, item_v):
         if not isinstance(item_v, str):
-            raise MyiaTypeError('item argument to getattr must be string.')
+            raise MyiaTypeError(
+                f'item argument to getattr must be string, not {item_v}.'
+            )
     return await static_getter(track, data, item, getattr, chk)
 
 

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -57,7 +57,7 @@ class TypeTrack(Track):
         else:
             return typeof(v)
 
-    def default(self):
+    def default(self, values):
         """Return a default type; this method raises an exception."""
         raise Exception('There is no default value for the type track.') \
             # pragma: no cover

--- a/myia/specialize.py
+++ b/myia/specialize.py
@@ -34,21 +34,21 @@ class TypeSpecializer:
     def __init__(self, engine):
         """Initialize a TypeSpecializer."""
         self.engine = engine
-
         self.mng = self.engine.mng
         self.node_map = self.mng.nodes
-
         self.originals = {}
         self.specializations = {}
         self.counts = Counter()
 
-        empty_ctx = Context.empty()
+    def run(self, graph, context):
+        """Run the specializer on the given graph in the given context."""
         ginf = GraphInferrer(self.engine.tracks['type'],
-                             engine.graph,
-                             empty_ctx)
-        argrefs = self.engine.argrefs
+                             graph, Context.empty())
 
-        self.result = self.engine.run_coroutine(
+        argrefs = [self.engine.ref(p, context)
+                   for p in graph.parameters]
+
+        return self.engine.run_coroutine(
             self._specialize(None, ginf, argrefs)
         )
 

--- a/myia/utils/__init__.py
+++ b/myia/utils/__init__.py
@@ -7,7 +7,7 @@ from .merge import (  # noqa
 
 from .misc import (  # noqa
     Named, UNKNOWN, Registry, repr_, list_str, TypeMap, StructuralMap, smap,
-    Event, Events, NS, Namespace, ModuleNamespace, ClosureNamespace
+    Event, Events, NS, Namespace, ModuleNamespace, ClosureNamespace, eprint
 )
 
 from .partial import (  # noqa

--- a/myia/utils/__init__.py
+++ b/myia/utils/__init__.py
@@ -13,3 +13,8 @@ from .misc import (  # noqa
 from .partial import (  # noqa
     partition_keywords, Partial, Partializable
 )
+
+from .unify import (  # noqa
+    Unification, Var, Seq, SVar, UnionVar, RestrictedVar, PredicateSet,
+    FilterVar, var, svar, uvar, expandlist, noseq, VisitError
+)

--- a/myia/utils/misc.py
+++ b/myia/utils/misc.py
@@ -1,6 +1,7 @@
 """Miscellaneous utilities."""
 
 import builtins
+import sys
 from typing import Any, Dict, List, TypeVar
 
 
@@ -400,3 +401,8 @@ class ClosureNamespace(Namespace):
             return d[name].cell_contents
         except ValueError as e:
             raise UnboundLocalError(name)
+
+
+def eprint(*things):
+    """Print to stderr."""
+    print(*things, file=sys.stderr)

--- a/myia/utils/misc.py
+++ b/myia/utils/misc.py
@@ -3,6 +3,7 @@
 import builtins
 import sys
 from typing import Any, Dict, List, TypeVar
+from colorama import AnsiToWin32
 
 
 builtins_d = vars(builtins)
@@ -403,6 +404,9 @@ class ClosureNamespace(Namespace):
             raise UnboundLocalError(name)
 
 
+stderr = AnsiToWin32(sys.stderr).stream
+
+
 def eprint(*things):
     """Print to stderr."""
-    print(*things, file=sys.stderr)
+    print(*things, file=stderr)

--- a/myia/utils/unify.py
+++ b/myia/utils/unify.py
@@ -29,8 +29,6 @@ def _get_next_tag():
 class Var:
     """Basic universal variable type."""
 
-    __slots__ = ('tag',)
-
     def __init__(self, tag: str = None) -> None:
         """Optionally set a tag."""
         if tag is not None:
@@ -205,8 +203,6 @@ class PredicateSet:
 
 class FilterVar(Var):
     """Variable restricted to values that pass a filter function."""
-
-    __slots__ = ('filter',)
 
     def __init__(self, filter: FnFiltT) -> None:
         """Create a FilterVar."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 asttokens
+colorama
 pytest
 pytest-cov
 codecov

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.7'
     ],
     packages=find_packages(exclude=['docs', 'tests']),
     install_requires=['asttokens'],

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'Programming Language :: Python :: 3.7'
     ],
     packages=find_packages(exclude=['docs', 'tests']),
-    install_requires=['asttokens'],
+    install_requires=['asttokens', 'colorama'],
     extras_require={
         'test': ['flake8', 'pytest', 'codecov',
                  'pytest-cov', 'pydocstyle'],

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -7,6 +7,7 @@ from pytest import mark
 from types import SimpleNamespace
 
 from myia.api import scalar_pipeline, standard_pipeline
+from myia.debug.traceback import print_inference_error
 from myia.infer import \
     ANYTHING, InferenceError, register_inferrer
 from myia.dtype import Array as A, Bool, Int, Float, Tuple as T, List as L, \
@@ -178,13 +179,17 @@ def inferrer_decorator(pipeline):
                     try:
                         out()
                     except InferenceError as e:
-                        pass
+                        print_inference_error(e)
                     else:
                         raise Exception(
                             f'Expected {expected_out}, got: (see stdout).'
                         )
                 else:
-                    assert out() == expected_out
+                    try:
+                        assert out() == expected_out
+                    except InferenceError as e:
+                        print_inference_error(e)
+                        raise
 
             m = mark.parametrize('spec', list(tests))(run_test)
             m.__orig__ = fn

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -923,7 +923,7 @@ def _square(x):
 
 @infer(type=(InferenceError,))
 def test_nonexistent_variable():
-    return xxxx + yz
+    return xxxx + yz  # noqa
 
 
 helpers = SimpleNamespace(

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -52,6 +52,26 @@ af64 = A(f64)
 Nil = T()
 
 
+def ai64_of(*shp):
+    return {'type': ai64, 'shape': shp}
+
+
+def ai32_of(*shp):
+    return {'type': ai32, 'shape': shp}
+
+
+def af64_of(*shp):
+    return {'type': af64, 'shape': shp}
+
+
+def af32_of(*shp):
+    return {'type': af32, 'shape': shp}
+
+
+def af16_of(*shp):
+    return {'type': af16, 'shape': shp}
+
+
 ########################
 # Temporary primitives #
 ########################
@@ -1048,44 +1068,43 @@ def test_shape(ary):
     return shape(ary)
 
 
-@infer(shape=[({'type': af64, 'shape': (2, 3)},
-               {'type': af64, 'shape': (3, 4)}, (2, 4)),
-              ({'type': af64, 'shape': (2,)},
-               {'type': af64, 'shape': (3, 4)}, InferenceError),
-              ({'type': af64, 'shape': (2, 2)},
-               {'type': af64, 'shape': (3, 4)}, InferenceError)],
-       type=[({'type': af64, 'shape': (2, 3)},
-              {'type': af64, 'shape': (3, 4)}, af64)])
+@infer(shape=[(af64_of(2, 3),
+               af64_of(3, 4), (2, 4)),
+              (af64_of(2),
+               af64_of(3, 4), InferenceError),
+              (af64_of(2, 2),
+               af64_of(3, 4), InferenceError)],
+       type=[(af64_of(2, 3),
+              af64_of(3, 4), af64)])
 def test_dot(a, b):
     return dot(a, b)
 
 
-@infer(shape=[({'type': ai32, 'shape': (4,)}, {'value': (2, 4)}, (2, 4)),
-              ({'type': ai32, 'shape': (4,)},
+@infer(shape=[(ai32_of(4), {'value': (2, 4)}, (2, 4)),
+              (ai32_of(4),
                {'type': T(u64, u64)},
                (ANYTHING, ANYTHING)),
-              ({'type': ai32, 'shape': (4,)}, {'value': (5, 2)},
+              (ai32_of(4), {'value': (5, 2)},
                InferenceError),
               ({'type': ai32, 'shape': (4, 2)}, {'value': (4,)},
                InferenceError)],
        type=[
-           ({'type': i32}, {'value': (4,), 'type': T(u64)}, InferenceError),
-           ({'type': ai32, 'shape': (1,)}, {'value': (4,), 'type': T(u64)},
-            ai32),
-           ({'type': li32}, {'value': (4,), 'type': T(u64)}, InferenceError),
-           ({'type': i32}, {'value': (4,)}, InferenceError)
+           (i32, {'value': (4,), 'type': T(u64)}, InferenceError),
+           (ai32_of(1), {'value': (4,), 'type': T(u64)}, ai32),
+           (li32, {'value': (4,), 'type': T(u64)}, InferenceError),
+           (i32, {'value': (4,)}, InferenceError)
        ])
 def test_distribute(v, shp):
     return distribute(v, shp)
 
 
-@infer(shape=[({'type': af16, 'shape': (1, 2, 3)}, {'value': (6,)}, (6,)),
-              ({'type': af16, 'shape': (1, 2, 3)}, {'type': T(u64)},
+@infer(shape=[(af16_of(1, 2, 3), {'value': (6,)}, (6,)),
+              (af16_of(1, 2, 3), {'type': T(u64)},
                (ANYTHING,)),
-              ({'type': af16, 'shape': (2, 3)}, {'value': (7,)},
+              (af16_of(2, 3), {'value': (7,)},
                InferenceError)],
-       type=[({'type': af16, 'shape': (2, 3)}, {'type': T(u64)}, af16),
-             ({'type': af16, 'shape': (2, 3)}, {'type': T(i64)},
+       type=[(af16_of(2, 3), T(u64), af16),
+             (af16_of(2, 3), T(i64),
               InferenceError)])
 def test_reshape(v, shp):
     return reshape(v, shp)
@@ -1100,31 +1119,25 @@ def test_array_map(ary):
     return array_map(f, ary)
 
 
-@infer(shape=[({'type': af32, 'shape': (3, 4)},
-               {'type': af32, 'shape': (3, 4)},
-               (3, 4)),
-              ({'type': af32, 'shape': (3, 4)},
-               {'type': af32, 'shape': (3, 7)},
-               InferenceError),
-              ({'type': af32, 'shape': (3, 4, 5)},
-               {'type': af32, 'shape': (3, 4)},
-               InferenceError)],
-       type=[({'type': ai64}, {'type': ai64}, ai64),
-             ({'type': ai64}, {'type': i64}, InferenceError),
-             ({'type': i64}, {'type': ai64}, InferenceError)])
+@infer(shape=[(af32_of(3, 4), af32_of(3, 4), (3, 4)),
+              (af32_of(3, 4), af32_of(3, 7), InferenceError),
+              (af32_of(3, 4, 5), af32_of(3, 4), InferenceError)],
+       type=[(ai64_of(7, 9), ai64_of(7, 9), ai64),
+             (ai64_of(7, 9), i64, InferenceError),
+             (i64, ai64_of(7, 9), InferenceError)])
 def test_array_map2(ary1, ary2):
     def f(v1, v2):
         return v1 + v2
     return array_map2(f, ary1, ary2)
 
 
-@infer(shape=[({'type': ai64, 'shape': (3, 4)}, {'value': 1}, (3, 4))],
+@infer(shape=[(ai64_of(3, 4), {'value': 1}, (3, 4))],
        type=[
-           ({'type': ai64, 'shape': (3, 4)}, {'value': 1, 'type': u64}, ai64),
+           (ai64_of(3, 4), {'value': 1, 'type': u64}, ai64),
            ({'type': i64}, {'value': 1, 'type': u64}, InferenceError),
-           ({'type': af32, 'shape': (3, 4)}, {'value': 1, 'type': u64},
+           (af32_of(3, 4), {'value': 1, 'type': u64},
             InferenceError),
-           ({'type': ai64, 'shape': (3, 4)}, {'value': 1}, InferenceError)
+           (ai64_of(3, 4), {'value': 1}, InferenceError)
        ])
 def test_array_scan(ary, ax):
     def f(a, b):
@@ -1134,32 +1147,32 @@ def test_array_scan(ary, ax):
 
 @infer(
     type=[
-        (ai64, T([u64, u64]), ai64),
-        (ai64, i64, InferenceError),
+        (ai64_of(7, 9), T([u64, u64]), ai64),
+        (ai64_of(7, 9), i64, InferenceError),
         (i64, T([u64, u64]), InferenceError),
     ],
     shape=[
-        ({'type': ai64, 'shape': (3, 4)},
+        (ai64_of(3, 4),
          {'value': (3, 1)},
          (3, 1)),
 
-        ({'type': ai64, 'shape': (3, 4)},
+        (ai64_of(3, 4),
          {'value': (3, ANYTHING)},
          (3, ANYTHING)),
 
-        ({'type': ai64, 'shape': (3, 4)},
+        (ai64_of(3, 4),
          {'value': (3, 1, 1)},
          InferenceError),
 
-        ({'type': ai64, 'shape': (3, 4)},
+        (ai64_of(3, 4),
          {'value': (4, 1)},
          InferenceError),
 
-        ({'type': ai64, 'shape': (3, 4)},
+        (ai64_of(3, 4),
          {'value': (4,)},
          (4,)),
 
-        ({'type': ai64, 'shape': (3, 4)},
+        (ai64_of(3, 4),
          {'value': ()},
          ()),
     ]
@@ -1196,7 +1209,7 @@ def test_partial_2(x):
 
 
 @infer(type=[(i64, i64)],
-       shape=[({'type': ai64, 'shape': (6, 13)}, (6, 13))])
+       shape=[(ai64_of(6, 13), (6, 13))])
 def test_identity_function(x):
     return identity(x)
 
@@ -1230,23 +1243,23 @@ def test_bool_or(x, y):
     ],
     shape=[
         ({'type': B},
-         {'type': ai64, 'shape': (6, 13)},
-         {'type': ai64, 'shape': (6, 13)},
+         ai64_of(6, 13),
+         ai64_of(6, 13),
          (6, 13)),
 
         ({'type': B},
-         {'type': ai64, 'shape': (6, 13)},
-         {'type': ai64, 'shape': (6, 14)},
+         ai64_of(6, 13),
+         ai64_of(6, 14),
          InferenceError),
 
         ({'type': B, 'value': True},
-         {'type': ai64, 'shape': (6, 13)},
-         {'type': ai64, 'shape': (6, 14)},
+         ai64_of(6, 13),
+         ai64_of(6, 14),
          (6, 13)),
 
         ({'type': B, 'value': False},
-         {'type': ai64, 'shape': (6, 13)},
-         {'type': ai64, 'shape': (6, 14)},
+         ai64_of(6, 13),
+         ai64_of(6, 14),
          (6, 14)),
     ]
 )
@@ -1256,7 +1269,7 @@ def test_switch(c, x, y):
 
 @infer(type=[(i64, ai64),
              (f64, af64),
-             (af64, InferenceError),
+             (af64_of(9, 7), InferenceError),
              (T([i64]), InferenceError)],
        shape=[({'type': i64}, ())])
 def test_scalar_to_array(x):
@@ -1394,18 +1407,14 @@ def test_forced_function_type():
 ###########################
 
 
-def ai64_of(*shp):
-    return {'type': ai64, 'shape': shp}
-
-
 @infer_std(
     type=[
         (i64, i64, i64),
-        (ai64, ai64, ai64),
-        (ai64, i64, ai64),
-        (i64, ai64, ai64),
+        (ai64_of(7, 9), ai64_of(7, 9), ai64),
+        (ai64_of(7, 9), i64, ai64),
+        (i64, ai64_of(7, 9), ai64),
         (i64, f64, InferenceError),
-        ({'type': i64, 'value': 3}, ai64, ai64)
+        ({'type': i64, 'value': 3}, ai64_of(7, 9), ai64)
     ],
     shape=[
         (ai64_of(2, 5), ai64_of(2, 5), (2, 5)),
@@ -1423,7 +1432,7 @@ def test_add_std(x, y):
 
 
 @infer_std(type=[(i64, i64, i64),
-                 (ai64, i64, InferenceError)])
+                 (ai64_of(7, 9), i64, InferenceError)])
 def test_max_std(x, y):
     if x > y:
         return x

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -212,9 +212,29 @@ type_signature_arith_bin = [
 ]
 
 
+@infer(type=[(i64, i64)], value=[(89, 89)])
+def test_identity(x):
+    return x
+
+
+@infer(type=[(i64,)], value=[(16,)])
+def test_constants_int():
+    return 2 * 8
+
+
 @infer(type=[(f64,)], value=[(12.0,)])
-def test_constants():
+def test_constants_float():
     return 1.5 * 8.0
+
+
+@infer(type=[(f64,)], value=[(12.0,)])
+def test_constants_intxfloat():
+    return 8 * 1.5
+
+
+@infer(type=[(f64,)], value=[(12.0,)])
+def test_constants_floatxint():
+    return 1.5 * 8
 
 
 @infer(type=type_signature_arith_bin)
@@ -278,7 +298,7 @@ def test_if2(x, y):
     type=[
         (i64, i64, i64),
         (i64, f64, f64),
-        (f64, f64, InferenceError),
+        (f64, f64, f64),
         ({'value': 1_000_000}, i64, i64)
     ],
     value=[
@@ -421,7 +441,7 @@ def test_return_closure(w, x, y, z):
     return (mul(w)(x), mul(y)(z))
 
 
-@infer(type=[(i64, i64), (f64, InferenceError)])
+@infer(type=[(i64, i64), (f64, f64)])
 def test_fact(n):
     def fact(n):
         if n <= 1:
@@ -445,7 +465,7 @@ def odd(n):
         return even(n - 1)
 
 
-@infer(type=[(i64, B), (f64, InferenceError)])
+@infer(type=[(i64, B), (f64, B)])
 def test_even_odd(n):
     return even(n)
 
@@ -828,7 +848,7 @@ def test_typeof(x):
         (T(i64, i64), i64),
         (T(i64, T(f64, i64)), i64),
         (li64, f64),
-        (T(i64, li64), InferenceError),
+        (T(i64, li64), i64),
     ],
     value=[
         (5, 5),
@@ -1146,7 +1166,7 @@ def test_partial_2(x):
 
 @infer(type=[(i64, i64)],
        shape=[({'type': ai64, 'shape': (6, 13)}, (6, 13))])
-def test_identity(x):
+def test_identity_function(x):
     return identity(x)
 
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -921,6 +921,11 @@ def _square(x):
     return x * x
 
 
+@infer(type=(InferenceError,))
+def test_nonexistent_variable():
+    return xxxx + yz
+
+
 helpers = SimpleNamespace(
     add=operator.add,
     mul=operator.mul,

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,4 +1,4 @@
-from myia.info import DebugInfo, DebugInherit, NamedDebugInfo
+from myia.info import DebugInfo, DebugInherit, NamedDebugInfo, About
 
 
 def test_nested_info():
@@ -35,3 +35,17 @@ def test_info_obj():
     assert d.obj is o
     del o
     assert d.obj is None
+
+
+def test_info_find():
+    a = NamedDebugInfo()
+    a.field1 = 1
+    a.field2 = 2
+    with About(a, 'thing'):
+        b = NamedDebugInfo()
+        b.field2 = 3
+    assert a.find('field1') == 1
+    assert a.find('field2') == 2
+    assert b.find('field1') == 1
+    assert b.find('field2') == 3
+    assert b.find('field3') is None

--- a/tests/test_specialize.py
+++ b/tests/test_specialize.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 
 from myia.api import scalar_debug_pipeline
 from myia.dtype import Function, Type, Problem, External
+from myia.debug.label import short_labeler as lbl
 from myia.graph_utils import dfs
 from myia.infer import Inferrer
 from myia.ir import succ_deeper, is_apply, is_constant
@@ -87,7 +88,7 @@ def specialize(*arglists):
             if errs:
                 print('Collected the following errors:')
                 for node, e in errs.items():
-                    print(f'   {node}')
+                    print(f'   {lbl.label(node)}')
                     print(f'      {" ".join(e)}')
                 raise Exception('There are errors in the specialized graph.')
             result_final = res['output'](*args)


### PR DESCRIPTION
* Splits inference into several files in the `myia/infer` submodule.
* Checking function equality is simpler and more reliable.
* Inference can now work with Var instances and perform unification when needed.
* Int/float literals are automatically converted to a compatible type when used in operations with user-provided data.
* When `myia.debug.traceback` is imported and an InferenceError is raised, an informative traceback is printed out. That traceback lists argument types for every function in the call path, highlights the calls, and prints out an informative error message.

Note: the newly-added `contextvars` module is used in order to keep traceback information, which means this branch requires Python 3.7+. I am supposing that won't be an issue.

### Remaining issues

* If `x` is an integer, the code in this PR will silently convert `1.5 + x` into `int(1.5) + x`. As discussed in the meeting of August 7, this is probably not what we want.
* The traceback may contain entries that correspond to functions generated by the parser, e.g. you might see an entry for `↓f(Φx: Int(64))` instead of `f(x: Int(64), y: Int(64))`. This isn't a huge problem since the original source code is highlighted anyway, but it could be a little confusing.
