### PR TITLE
Classes

### DIFF
--- a/myia/dtype.py
+++ b/myia/dtype.py
@@ -104,11 +104,21 @@ class Type(metaclass=TypeMeta):
         return f"{name}({args})"
 
 
-class Bool(Type):
+class Object(Type):
+    """Some object."""
+
+    @classmethod
+    def _parse_args(cls, args, kwargs):
+        if cls is Object:
+            raise RuntimeError("Can't instantiate Object directly")
+        return args
+
+
+class Bool(Object):
     """Boolean values."""
 
 
-class Number(Type):
+class Number(Object):
     """Numerical values."""
 
     bits: int
@@ -155,7 +165,7 @@ class UInt(Number):
     _valid_bits = (8, 16, 32, 64)
 
 
-class List(Type):
+class List(Object):
     """Represents a set of ordered values with the same type.
 
     Instanciate with `List(element_type)`.
@@ -164,7 +174,7 @@ class List(Type):
     element_type: Type
 
 
-class Struct(Type):
+class Struct(Object):
     """Represents a set of named fields with their own types.
 
     Instantiate with `Struct(Mapping[str, Type])`.  A sequence of
@@ -195,7 +205,7 @@ class Struct(Type):
         raise AttributeError
 
 
-class Tuple(Type):
+class Tuple(Object):
     """Represents a set of ordered values with independent types.
 
     Instantiate with `Tuple(type1, type2, ... typeN)`.  A single
@@ -214,7 +224,7 @@ class Tuple(Type):
             return (args,)
 
 
-class Array(Type):
+class Array(Object):
     """Represents an array of values.
 
     Instantiate with Array(subtype).
@@ -223,7 +233,7 @@ class Array(Type):
     elements: Type
 
 
-class Function(Type):
+class Function(Object):
     """Represents a type that can be called.
 
     Instantiate with `Function((type1, type2, ..., typeN), ret_type)`.
@@ -238,6 +248,10 @@ class Function(Type):
         assert len(kwargs) == 0
         assert not isinstance(args[0], Type)
         return (tuple(args[0]), args[1])
+
+
+class TypeType(Type):
+    """The type of a Type."""
 
 
 class Problem(Type):

--- a/myia/dtype.py
+++ b/myia/dtype.py
@@ -4,7 +4,7 @@ import collections
 import numpy
 from typing import Any, Dict as DictT, Iterable, Tuple as TupleT
 from types import FunctionType
-from .utils import Named, is_dataclass
+from .utils import Named, is_dataclass_type
 
 KeysT = Iterable[TupleT[str, 'Type']]
 
@@ -360,7 +360,7 @@ def pytype_to_myiatype(pytype, instance=None):
         else:
             return Array(DTYPE_MAP[instance.dtype.name])
 
-    elif is_dataclass(pytype):
+    elif is_dataclass_type(pytype):
         if pytype in dataclass_to_myiaclass:
             mcls = dataclass_to_myiaclass[pytype]
             if instance is None:

--- a/myia/dtype.py
+++ b/myia/dtype.py
@@ -366,8 +366,10 @@ def pytype_to_myiatype(pytype, instance=None):
             if instance is None:
                 return mcls
             tag = mcls.tag
-        else:
+        elif instance is None:
             tag = Named(pytype.__name__)
+        else:
+            tag = pytype_to_myiatype(pytype).tag
 
         fields = pytype.__dataclass_fields__
         if instance is None:
@@ -383,8 +385,9 @@ def pytype_to_myiatype(pytype, instance=None):
                    for name in dir(pytype)
                    if isinstance(getattr(pytype, name), (FunctionType,))}
         rval = Class(tag, attributes, methods)
-        dataclass_to_myiaclass[pytype] = rval
-        tag_to_dataclass[tag] = pytype
+        if pytype not in dataclass_to_myiaclass:
+            dataclass_to_myiaclass[pytype] = rval
+            tag_to_dataclass[tag] = pytype
         return rval
 
     else:

--- a/myia/prim/ops.py
+++ b/myia/prim/ops.py
@@ -13,8 +13,6 @@ from ..utils import Named
 class Primitive(Named):
     """Base class for primitives."""
 
-    pass
-
 
 ##############
 # Arithmetic #
@@ -115,3 +113,4 @@ list_map = Primitive('list_map')
 identity = Primitive('identity')
 resolve = Primitive('resolve')
 partial = Primitive('partial')
+make_record = Primitive('make_record')

--- a/myia/prim/py_implementations.py
+++ b/myia/prim/py_implementations.py
@@ -5,7 +5,7 @@ from typing import Callable
 import numpy as np
 
 from .. import dtype as types
-from ..utils import Registry
+from ..utils import Registry, TypeMap
 
 from . import ops as primops
 
@@ -167,21 +167,37 @@ def typeof(x):
     """Implement typeof."""
     if isinstance(x, types.Type) or isinstance(x, type):
         return types.TypeType()
-    elif isinstance(x, bool):
-        return types.Bool()
-    elif isinstance(x, int):
-        return types.Int(64)
-    elif isinstance(x, float):
-        return types.Float(64)
-    elif isinstance(x, tuple):
-        return types.Tuple(map(typeof, x))
-    elif isinstance(x, list) and len(x) > 0:
-        type0, *rest = map(typeof, x)
-        if any(t != type0 for t in rest):
-            raise TypeError(f'All list elements should have same type')
-        return types.List(type0)
     else:
-        return types.External(type(x))
+        return types.pytype_to_myiatype(type(x), x)
+
+
+hastype_helper_map = TypeMap()
+
+
+@hastype_helper_map.register(types.Array)
+def _hh_Array(t, model):
+    return hastype_helper(t.elements, model.elements)
+
+
+@hastype_helper_map.register(types.Tuple)
+def _hh_Tuple(t, model):
+    if len(t.elements) != len(model.elements):
+        return False
+    return all(hastype_helper(t1, t2)
+               for t1, t2 in zip(t.elements, model.elements))
+
+
+@hastype_helper_map.register(types.Class)
+def _hh_Class(t, model):
+    if t.tag != model.tag:
+        return False
+    if tuple(t.attributes.keys()) != tuple(model.attributes.keys()):
+        raise AssertionError(
+            'Identical Class tags should imply identical attributes.'
+        )
+    return all(hastype_helper(t1, t2)
+               for t1, t2 in zip(t.attributes.values(),
+                                 model.attributes.values()))
 
 
 def hastype_helper(t, model):
@@ -190,6 +206,8 @@ def hastype_helper(t, model):
         return True
     elif isinstance(model, type) and issubclass(model, types.Type):
         return isinstance(t, model)
+    elif type(t) is type(model):
+        return hastype_helper_map[type(t)](t, model)
     else:
         return False
 
@@ -489,3 +507,10 @@ def broadcast_shape(shpx, shpy):
                 f'Cannot broadcast shapes {orig_shpx} and {orig_shpy}.'
             )
     return tuple(shp)
+
+
+@register(primops.make_record)
+def make_record(typ, *args):
+    """Implement `make_record`."""
+    dataclass = types.tag_to_dataclass[typ.tag]
+    return dataclass(*args)

--- a/myia/prim/py_implementations.py
+++ b/myia/prim/py_implementations.py
@@ -166,7 +166,7 @@ def bool_or(x, y):
 def typeof(x):
     """Implement typeof."""
     if isinstance(x, types.Type) or isinstance(x, type):
-        return types.Type
+        return types.TypeType()
     elif isinstance(x, bool):
         return types.Bool()
     elif isinstance(x, int):

--- a/myia/prim/shape_inferrers.py
+++ b/myia/prim/shape_inferrers.py
@@ -7,7 +7,7 @@ from ..infer import ANYTHING, GraphInferrer, register_inferrer, \
     PartialInferrer, Track, MyiaShapeError, Inferrer,  MetaGraphInferrer
 from ..ir import Graph, MetaGraph
 from ..dtype import Array
-from ..utils import is_dataclass
+from ..utils import is_dataclass_type
 
 from . import ops as P
 from .inferrer_utils import static_getter
@@ -66,7 +66,7 @@ class ShapeTrack(Track):
             return GraphInferrer(self, v, context)
         elif isinstance(v, MetaGraph):
             return MetaGraphInferrer(self, v)
-        elif is_dataclass(v):
+        elif is_dataclass_type(v):
             raise NotImplementedError('Dataclasses are not supported yet')
         else:
             return getattr(v, 'shape', ())

--- a/myia/prim/shape_inferrers.py
+++ b/myia/prim/shape_inferrers.py
@@ -7,6 +7,7 @@ from ..infer import ANYTHING, GraphInferrer, register_inferrer, \
     PartialInferrer, Track, MyiaShapeError, Inferrer,  MetaGraphInferrer
 from ..ir import Graph, MetaGraph
 from ..dtype import Array
+from ..utils import is_dataclass
 
 from . import ops as P
 from .inferrer_utils import static_getter
@@ -65,6 +66,8 @@ class ShapeTrack(Track):
             return GraphInferrer(self, v, context)
         elif isinstance(v, MetaGraph):
             return MetaGraphInferrer(self, v)
+        elif is_dataclass(v):
+            raise NotImplementedError('Dataclasses are not supported yet')
         else:
             return getattr(v, 'shape', ())
 

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -8,7 +8,7 @@ from ..dtype import Int, Float, Bool, Tuple, List, Array, UInt, Number, \
 from ..infer import ANYTHING, GraphInferrer, PartialInferrer, \
     MyiaTypeError, register_inferrer, Track, MetaGraphInferrer
 from ..ir import Graph, MetaGraph
-from ..utils import Namespace, FilterVar, is_dataclass
+from ..utils import Namespace, FilterVar, is_dataclass_type
 
 from . import ops as P
 from .inferrer_utils import static_getter
@@ -71,7 +71,7 @@ class TypeTrack(Track):
             return GraphInferrer(self, v, context)
         elif isinstance(v, MetaGraph):
             return MetaGraphInferrer(self, v)
-        elif is_dataclass(v):
+        elif is_dataclass_type(v):
             rec = self.constructors[P.make_record](self)
             typ = pytype_to_myiatype(v)
             vref = self.engine.vref({'value': typ, 'type': TypeType()})
@@ -193,7 +193,7 @@ async def infer_type_hastype(track, x, t):
     """Infer the return type of hastype."""
     def istype(x):  # noqa: D400
         """Type"""
-        return x == TypeType()
+        return x is TypeType()
 
     await track.check(istype, t)
     return Bool()

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -3,7 +3,8 @@
 
 from functools import partial
 
-from ..dtype import Int, Float, Bool, Tuple, List, Type, Array, UInt, Number
+from ..dtype import Int, Float, Bool, Tuple, List, Array, UInt, Number, \
+    TypeType
 from ..infer import ANYTHING, GraphInferrer, PartialInferrer, \
     MyiaTypeError, register_inferrer, Track, MetaGraphInferrer
 from ..ir import Graph, MetaGraph
@@ -179,7 +180,7 @@ async def infer_type_getitem(track, seq, idx):
 @type_inferrer(P.typeof, nargs=1)
 async def infer_type_typeof(track, _):
     """Infer the return type of typeof."""
-    return Type
+    return TypeType()
 
 
 @type_inferrer(P.hastype, nargs=2)
@@ -187,7 +188,7 @@ async def infer_type_hastype(track, x, t):
     """Infer the return type of hastype."""
     def istype(x):  # noqa: D400
         """Type"""
-        return x is Type
+        return x == TypeType()
 
     await track.check(istype, t)
     return Bool()

--- a/myia/prim/value_inferrers.py
+++ b/myia/prim/value_inferrers.py
@@ -10,7 +10,7 @@ from ..infer import ValueWrapper, InferenceError, PartialInferrer, \
     ANYTHING, Inferrer, GraphInferrer, register_inferrer, Track, \
     unwrap, MetaGraphInferrer
 from ..ir import Graph, MetaGraph
-from ..utils import is_dataclass
+from ..utils import is_dataclass_type
 
 from . import ops as P
 from .inferrer_utils import static_getter
@@ -132,7 +132,7 @@ class ValueTrack(Track):
             inf = GraphInferrer(self, v, context)
         elif isinstance(v, MetaGraph):
             inf = MetaGraphInferrer(self, v)
-        elif is_dataclass(v):
+        elif is_dataclass_type(v):
             p = P.make_record
             recinf = PrimitiveValueInferrer(self, p, self.implementations[p])
             typ = pytype_to_myiatype(v)

--- a/myia/prim/value_inferrers.py
+++ b/myia/prim/value_inferrers.py
@@ -5,10 +5,12 @@ import asyncio
 
 from functools import partial
 
+from ..dtype import pytype_to_myiatype, TypeType
 from ..infer import ValueWrapper, InferenceError, PartialInferrer, \
     ANYTHING, Inferrer, GraphInferrer, register_inferrer, Track, \
     unwrap, MetaGraphInferrer
 from ..ir import Graph, MetaGraph
+from ..utils import is_dataclass
 
 from . import ops as P
 from .inferrer_utils import static_getter
@@ -130,6 +132,13 @@ class ValueTrack(Track):
             inf = GraphInferrer(self, v, context)
         elif isinstance(v, MetaGraph):
             inf = MetaGraphInferrer(self, v)
+        elif is_dataclass(v):
+            p = P.make_record
+            recinf = PrimitiveValueInferrer(self, p, self.implementations[p])
+            typ = pytype_to_myiatype(v)
+            vref = self.engine.vref({'value': limited(typ, self.max_depth),
+                                     'type': TypeType()})
+            return PartialInferrer(self, recinf, [vref])
         elif v is ANYTHING:
             return v
         else:

--- a/myia/specialize.py
+++ b/myia/specialize.py
@@ -2,7 +2,7 @@
 
 from collections import Counter
 
-from .dtype import Type, Function, Number, Bool, Problem
+from .dtype import Type, Function, Number, Bool, Problem, TypeType
 from .infer import ANYTHING, Context, reify, \
     GraphInferrer, MetaGraphInferrer, PartialInferrer, Inferrer
 from .ir import GraphCloner, is_apply, is_constant_graph, Constant
@@ -197,6 +197,7 @@ class _GraphSpecializer:
 
     @build_map.register(Number)
     @build_map.register(Bool)
+    @build_map.register(TypeType)
     @build_map.register(type)
     async def build_atom(self, ref, argrefs, t):
         v = await ref['value']

--- a/myia/utils/__init__.py
+++ b/myia/utils/__init__.py
@@ -8,7 +8,7 @@ from .merge import (  # noqa
 from .misc import (  # noqa
     Named, UNKNOWN, Registry, repr_, list_str, TypeMap, StructuralMap, smap,
     Event, Events, NS, Namespace, ModuleNamespace, ClosureNamespace, eprint,
-    is_dataclass
+    is_dataclass_type
 )
 
 from .partial import (  # noqa

--- a/myia/utils/__init__.py
+++ b/myia/utils/__init__.py
@@ -7,7 +7,8 @@ from .merge import (  # noqa
 
 from .misc import (  # noqa
     Named, UNKNOWN, Registry, repr_, list_str, TypeMap, StructuralMap, smap,
-    Event, Events, NS, Namespace, ModuleNamespace, ClosureNamespace, eprint
+    Event, Events, NS, Namespace, ModuleNamespace, ClosureNamespace, eprint,
+    is_dataclass
 )
 
 from .partial import (  # noqa

--- a/myia/utils/misc.py
+++ b/myia/utils/misc.py
@@ -410,3 +410,8 @@ stderr = AnsiToWin32(sys.stderr).stream
 def eprint(*things):
     """Print to stderr."""
     print(*things, file=stderr)
+
+
+def is_dataclass(cls):
+    """Returns whether cls is a dataclass."""
+    return isinstance(cls, type) and hasattr(cls, '__dataclass_fields__')

--- a/myia/utils/misc.py
+++ b/myia/utils/misc.py
@@ -412,6 +412,6 @@ def eprint(*things):
     print(*things, file=stderr)
 
 
-def is_dataclass(cls):
+def is_dataclass_type(cls):
     """Returns whether cls is a dataclass."""
     return isinstance(cls, type) and hasattr(cls, '__dataclass_fields__')

--- a/myia/vm.py
+++ b/myia/vm.py
@@ -14,7 +14,7 @@ from .prim import Primitive
 from .prim.py_implementations import typeof
 from .prim.ops import if_, return_, partial
 from .graph_utils import toposort
-from .utils import TypeMap, NS, is_dataclass
+from .utils import TypeMap, NS, is_dataclass_type
 
 
 class VMFrame:
@@ -262,7 +262,7 @@ class VM:
             res = NS(convert=self.convert, manager=self.manager)
             g = fn.specialize(res, types)
             self._dispatch_call(node, frame, g, args)
-        elif is_dataclass(fn):
+        elif is_dataclass_type(fn):
             frame.values[node] = fn(*args)
         else:
             raise AssertionError(f'Invalid fn to call: {fn}')

--- a/myia/vm.py
+++ b/myia/vm.py
@@ -14,7 +14,7 @@ from .prim import Primitive
 from .prim.py_implementations import typeof
 from .prim.ops import if_, return_, partial
 from .graph_utils import toposort
-from .utils import TypeMap, NS
+from .utils import TypeMap, NS, is_dataclass
 
 
 class VMFrame:
@@ -262,6 +262,8 @@ class VM:
             res = NS(convert=self.convert, manager=self.manager)
             g = fn.specialize(res, types)
             self._dispatch_call(node, frame, g, args)
+        elif is_dataclass(fn):
+            frame.values[node] = fn(*args)
         else:
             raise AssertionError(f'Invalid fn to call: {fn}')
 

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -117,6 +117,10 @@ def test_pytype_to_myiatype():
     assert ptm(numpy.ndarray) is Array
     assert ptm(numpy.ndarray, numpy.ones((2, 2))) is Array(Float(64))
 
+    # We run this before ptm(Point) to make sure it doesn't cache Float, Float
+    # for the type of x and y
+    ptm(Point, Point(1.1, 2.2))
+
     pcls = ptm(Point)
     assert isinstance(pcls, Class)
     assert pcls.attributes == {'x': Number, 'y': Number}

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -1,7 +1,19 @@
 import pytest
+import numpy
+from dataclasses import dataclass
 
-from myia.dtype import Bool, Float, Function, Int, List, Number, Struct, \
-    Tuple, Type, TypeMeta, UInt, np_dtype_to_type, type_to_np_dtype
+from myia.dtype import Bool, Float, Function, Int, List, Number, \
+    Tuple, Type, TypeMeta, UInt, np_dtype_to_type, type_to_np_dtype, Object, \
+    pytype_to_myiatype, Array, Class, External
+
+
+@dataclass(frozen=True)
+class Point:
+    x: Number
+    y: Number
+
+    def abs(self):
+        return (self.x ** 2 + self.y ** 2) ** 0.5
 
 
 def test_TypeMeta():
@@ -20,6 +32,11 @@ def test_TypeMeta():
 def test_Type():
     with pytest.raises(RuntimeError):
         Type()
+
+
+def test_Object():
+    with pytest.raises(RuntimeError):
+        Object()
 
 
 def test_cache():
@@ -41,21 +58,6 @@ def test_Number():
 def test_List():
     ll = List(Bool())
     assert ll.element_type is Bool()
-
-
-def test_Struct():
-    c64 = Struct((('r', Float(32)), ('i', Float(32))))
-    assert c64.r is Float(32)
-    assert c64.elements['i'] is Float(32)
-
-    with pytest.raises(AttributeError):
-        c64.foo
-
-    c64_2 = Struct(dict(r=Float(32), i=Float(32)))
-    assert c64 is c64_2
-
-    c64_3 = Struct(r=Float(32), i=Float(32))
-    assert c64 is c64_3
 
 
 def test_Tuple():
@@ -92,3 +94,38 @@ def test_type_conversions():
 
     with pytest.raises(TypeError):
         type_to_np_dtype(List(Int(64)))
+
+
+def test_pytype_to_myiatype():
+    ptm = pytype_to_myiatype
+
+    assert ptm(Int) is Int
+    assert ptm(Int(64)) is Int(64)
+
+    assert ptm(bool) is Bool()
+    assert ptm(int) is Int(64)
+    assert ptm(float) is Float(64)
+
+    assert ptm(tuple) is Tuple
+    assert ptm(tuple, (1, (2, 3))) is Tuple(Int(64), Tuple(Int(64), Int(64)))
+
+    assert ptm(list) is List
+    assert ptm(list, [1, 2, 3]) is List(Int(64))
+    with pytest.raises(TypeError):
+        ptm(list, [1, (2, 3)])
+
+    assert ptm(numpy.ndarray) is Array
+    assert ptm(numpy.ndarray, numpy.ones((2, 2))) is Array(Float(64))
+
+    pcls = ptm(Point)
+    assert isinstance(pcls, Class)
+    assert pcls.attributes == {'x': Number, 'y': Number}
+    assert 'abs' in pcls.methods
+    assert str(pcls.tag) == 'Point'
+
+    pcls2 = ptm(Point, Point(1, 2))
+    assert pcls2.tag is pcls.tag
+    assert pcls2.attributes == {'x': Int(64), 'y': Int(64)}
+
+    assert ptm(str) is External(str)
+    assert ptm(object) is External(object)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -11,7 +11,7 @@ from myia.infer import \
     ANYTHING, InferenceError, register_inferrer
 from myia.ir import MultitypeGraph
 from myia.dtype import Array as A, Bool, Int, Float, Tuple as T, List as L, \
-    Function as F, Type, UInt, External
+    Function as F, TypeType, UInt, External
 from myia.pipeline import pipeline_function
 from myia.prim import Primitive
 from myia.prim.py_implementations import \
@@ -875,14 +875,14 @@ def test_hastype(x):
 
 @infer(
     type=(i64, i64, InferenceError),
-    value=(i64, {'type': Type, 'value': ANYTHING}, InferenceError),
+    value=(i64, {'type': TypeType(), 'value': ANYTHING}, InferenceError),
 )
 def test_bad_hastype(x, y):
     return hastype(x, y)
 
 
 @infer(
-    type=[(i64, Type)],
+    type=[(i64, TypeType())],
     value=[({'type': i64}, i64),
            ({'type': f64}, f64)]
 )

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -1,6 +1,7 @@
 
 from copy import copy
 from types import SimpleNamespace
+from dataclasses import dataclass
 
 from pytest import mark
 
@@ -522,3 +523,17 @@ def test_fact(x):
         else:
             return n * fact(n - 1)
     return fact(x)
+
+
+@dataclass(frozen=True)
+class Point:
+    x: Int(64)
+    y: Int(64)
+
+    def abs(self):
+        return (self.x ** 2 + self.y ** 2) ** 0.5
+
+
+@parse_compare(42)
+def test_record(x):
+    return Point(x, x)


### PR DESCRIPTION
This adds support for Python 3.7's dataclasses through the `Class` type and the `make_record` primitive. Myia will recognize the attributes and methods of any class decorated with `@dataclass(frozen=True)`. `make_record(cls, *args)` is the Myia op used to instantiate a dataclass. Future optimization passes will transform these records into tuples, which should be straightforward to do with all the information collected by the inferrer.

This is built on top of PR #101.
