### PR TITLE
Rewrite dtype

### DIFF
--- a/myia/dtype.py
+++ b/myia/dtype.py
@@ -4,7 +4,7 @@
 import numpy
 from types import FunctionType
 from typing import Tuple as TupleT, Dict as DictT, Any
-from myia.utils import Named, is_dataclass_type
+from .utils import Named, is_dataclass_type, as_frozen
 
 
 _type_cache = {}
@@ -36,16 +36,6 @@ def get_generic(t1, t2):
         return t1.generic
     else:
         return None
-
-
-def _freeze(x):
-    """Return an immutable representation for x."""
-    if isinstance(x, dict):
-        return tuple((k, _freeze(v)) for k, v in x.items())
-    elif isinstance(x, list):
-        return tuple(x)
-    else:
-        return x
 
 
 class TypeMeta(type):
@@ -90,7 +80,7 @@ class TypeMeta(type):
         elif list(params.keys()) != fields:
             raise TypeError('Invalid type parameterization')
         else:
-            key = (cls, _freeze(params))
+            key = (cls, as_frozen(params))
             if key in _type_cache:
                 return _type_cache[key]
             rval = type(cls.__qualname__, (cls,), {'_params': params})

--- a/myia/infer/core.py
+++ b/myia/infer/core.py
@@ -4,7 +4,7 @@ import asyncio
 from contextvars import copy_context
 from collections import deque
 
-from ..dtype import Array, List, Tuple, Function
+from ..dtype import Array, List, Tuple, Function, TypeMeta
 from ..utils import TypeMap, Unification, Var, RestrictedVar, eprint
 
 from .utils import InferenceError, DynamicMap, MyiaTypeError, ValueWrapper
@@ -380,6 +380,14 @@ async def _reify_tuple(v):
 @_reify_map.register(int)
 async def _reify_int(v):
     return v
+
+
+@_reify_map.register(TypeMeta)
+async def _reify_tmeta(v):
+    if v.is_generic():
+        return v
+    else:
+        return await _reify_map[v](v)
 
 
 @_reify_map.register(type)

--- a/myia/infer/core.py
+++ b/myia/infer/core.py
@@ -201,8 +201,8 @@ class EquivalenceChecker:
                 # TODO: this should fetch the appropriate track, not
                 # necessarily 'type'
                 argt = [await ref['type'] for ref in argrefs]
-                t1 = Function(argt, err.type1)
-                t2 = Function(argt, err.type2)
+                t1 = Function[argt, err.type1]
+                t2 = Function[argt, err.type2]
                 err = MyiaFunctionMismatchError(t1, t2, refs=err.refs)
                 self.error_callback(err)
 
@@ -353,22 +353,22 @@ async def _reify_Var(v):
 
 @_reify_map.register(Array)
 async def _reify_Array(t):
-    return Array(await reify(t.elements))
+    return Array[await reify(t.elements)]
 
 
 @_reify_map.register(List)
 async def _reify_List(t):
-    return List(await reify(t.element_type))
+    return List[await reify(t.element_type)]
 
 
 @_reify_map.register(Tuple)
 async def _reify_Tuple(t):
-    return Tuple(await reify(t.elements))
+    return Tuple[await reify(t.elements)]
 
 
 @_reify_map.register(Function)
 async def _reify_Function(t):
-    return Function(await reify(t.arguments), await reify(t.retval))
+    return Function[await reify(t.arguments), await reify(t.retval)]
 
 
 @_reify_map.register(tuple)

--- a/myia/infer/graph_infer.py
+++ b/myia/infer/graph_infer.py
@@ -3,7 +3,7 @@
 import asyncio
 from types import FunctionType
 
-from ..dtype import Type, Function
+from ..dtype import ismyiatype, Type, Function
 from ..debug.label import label
 from ..ir import is_constant, is_constant_graph, is_apply, GraphGenerationError
 from ..utils import Partializable, UNKNOWN, eprint
@@ -64,7 +64,8 @@ class Track(Partializable):
             return ANYTHING
 
         argrefs = [self.engine.ref(node, ctx) for node in n_args]
-        if isinstance(inf, Function):
+        # if isinstance(inf, Function):
+        if isinstance(inf, type) and issubclass(inf, Function):
             ngot = len(argrefs)
             nexpect = len(inf.arguments)
             if ngot != nexpect:
@@ -126,10 +127,8 @@ class Track(Partializable):
         """
         if isinstance(predicate, tuple):
             return any(self.apply_predicate(p, res) for p in predicate)
-        elif isinstance(predicate, Type):
-            return res == predicate
-        elif isinstance(predicate, type) and issubclass(predicate, Type):
-            return isinstance(res, predicate)
+        elif ismyiatype(predicate):
+            return ismyiatype(res, predicate)
         elif callable(predicate):
             return predicate(res)
         else:
@@ -144,10 +143,7 @@ class Track(Partializable):
             ref: The reference that produced the value.
         """
         def is_type(preds):
-            return any(isinstance(pred, Type)
-                       or isinstance(pred, type)
-                       and issubclass(pred, Type)
-                       for pred in preds)
+            return any(ismyiatype(pred) for pred in preds)
 
         if not isinstance(predicate, tuple):
             predicate = (predicate,)

--- a/myia/infer/graph_infer.py
+++ b/myia/infer/graph_infer.py
@@ -3,7 +3,7 @@
 import asyncio
 from types import FunctionType
 
-from ..dtype import ismyiatype, Type, Function
+from ..dtype import ismyiatype, Function
 from ..debug.label import label
 from ..ir import is_constant, is_constant_graph, is_apply, GraphGenerationError
 from ..utils import Partializable, UNKNOWN, eprint

--- a/myia/ir/anf.py
+++ b/myia/ir/anf.py
@@ -61,8 +61,8 @@ class Graph:
         """Return the graph's type based on parameter/output types."""
         if any(p.type is UNKNOWN for p in self.parameters):
             return UNKNOWN
-        return Function(tuple(p.type for p in self.parameters),
-                        self.output.type)
+        return Function[tuple(p.type for p in self.parameters),
+                        self.output.type]
 
     @property
     def output(self) -> 'ANFNode':
@@ -88,7 +88,7 @@ class Graph:
             self.return_ = Apply([Constant(primops.return_), value], self)
         self.return_.type = value.type
         if value.type is not UNKNOWN:
-            self.return_.inputs[0].type = Function((value.type,), value.type)
+            self.return_.inputs[0].type = Function[(value.type,), value.type]
 
     def add_parameter(self) -> 'Parameter':
         """Add a new parameter to this graph (appended to the end)."""

--- a/myia/prim/inferrer_utils.py
+++ b/myia/prim/inferrer_utils.py
@@ -1,7 +1,7 @@
 """Utilities that may leveraged by several inferrers."""
 
 
-from ..dtype import Class
+from ..dtype import Class, ismyiatype
 from ..infer import InferenceError, PartialInferrer, Context, ANYTHING, unwrap
 
 
@@ -34,7 +34,7 @@ async def static_getter(track, data, item, fetch, chk=None):
             'The value of the attribute could not be inferred.'
         )
 
-    if isinstance(data_t, Class):
+    if ismyiatype(data_t, Class):
         # Get field from Class
         if item_v in data_t.attributes:
             if track.name == 'type':
@@ -62,7 +62,7 @@ async def static_getter(track, data, item, fetch, chk=None):
 
     # Try method map
     try:
-        mmap_t = mmap[type(data_t)]
+        mmap_t = mmap[data_t]
     except KeyError:
         mmap_t = None
 

--- a/myia/prim/py_implementations.py
+++ b/myia/prim/py_implementations.py
@@ -166,7 +166,7 @@ def bool_or(x, y):
 def typeof(x):
     """Implement typeof."""
     if isinstance(x, types.Type) or isinstance(x, type):
-        return types.TypeType()
+        return types.TypeType
     else:
         return types.pytype_to_myiatype(type(x), x)
 

--- a/myia/prim/py_implementations.py
+++ b/myia/prim/py_implementations.py
@@ -204,10 +204,10 @@ def hastype_helper(t, model):
     """Check that type t is represented by model."""
     if t == model:
         return True
-    elif isinstance(model, type) and issubclass(model, types.Type):
-        return isinstance(t, model)
-    elif type(t) is type(model):
-        return hastype_helper_map[type(t)](t, model)
+    elif types.ismyiatype(model, generic=True):
+        return types.ismyiatype(t, model)
+    elif types.get_generic(t, model):
+        return hastype_helper_map[t.generic](t, model)
     else:
         return False
 

--- a/myia/prim/shape_inferrers.py
+++ b/myia/prim/shape_inferrers.py
@@ -6,7 +6,7 @@ from functools import partial, reduce
 from ..infer import ANYTHING, GraphInferrer, register_inferrer, \
     PartialInferrer, Track, MyiaShapeError, Inferrer,  MetaGraphInferrer
 from ..ir import Graph, MetaGraph
-from ..dtype import Array
+from ..dtype import Array, ismyiatype
 from ..utils import is_dataclass_type
 
 from . import ops as P
@@ -181,7 +181,7 @@ async def infer_shape_distribute(track, v, shape):
         shp_t = await shape['type']
         shp = (ANYTHING,) * len(shp_t.elements)
     v_t = await v['type']
-    if isinstance(v_t, Array):
+    if ismyiatype(v_t, Array):
         v_shp = await v['shape']
         delta = len(shp) - len(v_shp)
         if delta < 0:

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -25,9 +25,9 @@ def _is_number(t):
 
 
 def _shape_type(t):  # noqa: D400
-    """Tuple(UInt(64) ...)"""
+    """Tuple[UInt[64] ...]"""
     # The docstring is used in the error message.
-    return ismyiatype(t, Tuple) and all(x == UInt(64) for x in t.elements)
+    return ismyiatype(t, Tuple) and all(x == UInt[64] for x in t.elements)
 
 
 class TypeTrack(Track):
@@ -75,7 +75,7 @@ class TypeTrack(Track):
         elif is_dataclass_type(v):
             rec = self.constructors[P.make_record](self)
             typ = pytype_to_myiatype(v)
-            vref = self.engine.vref({'value': typ, 'type': TypeType()})
+            vref = self.engine.vref({'value': typ, 'type': TypeType})
             return PartialInferrer(self, rec, [vref])
         else:
             return typeof(v)
@@ -98,7 +98,7 @@ type_inferrer = partial(register_inferrer,
 @type_inferrer(P.if_, nargs=3)
 async def infer_type_if(track, cond, tb, fb):
     """Infer the return type of if."""
-    await track.check(Bool(), cond)
+    await track.check(Bool, cond)
     tb_inf = await tb['type']
     fb_inf = await fb['type']
     v = await cond['value']
@@ -119,7 +119,7 @@ async def infer_type_if(track, cond, tb, fb):
 @type_inferrer(P.switch, nargs=3)
 async def infer_type_switch(track, cond, tb, fb):
     """Infer the return type of switch."""
-    await track.check(Bool(), cond)
+    await track.check(Bool, cond)
     v = await cond['value']
     if v is True:
         # We only visit the first branch if the condition is provably true
@@ -147,7 +147,7 @@ async def infer_type_cons_tuple(track, x, y):
     """Infer the return type of cons_tuple."""
     x_t = await x['type']
     y_t = await track.check(Tuple, y)
-    return Tuple([x_t, *y_t.elements])
+    return Tuple[[x_t, *y_t.elements]]
 
 
 @type_inferrer(P.head, nargs=1)
@@ -165,7 +165,7 @@ async def infer_type_tail(track, tup):
     tup_t = await track.check(Tuple, tup)
     if not len(tup_t.elements) >= 1:
         raise MyiaTypeError('tail on empty tuple', refs=[tup])
-    return Tuple(tup_t.elements[1:])
+    return Tuple[tup_t.elements[1:]]
 
 
 @type_inferrer(P.getitem, nargs=2)
@@ -186,7 +186,7 @@ async def infer_type_getitem(track, seq, idx):
 @type_inferrer(P.typeof, nargs=1)
 async def infer_type_typeof(track, _):
     """Infer the return type of typeof."""
-    return TypeType()
+    return TypeType
 
 
 @type_inferrer(P.hastype, nargs=2)
@@ -194,45 +194,45 @@ async def infer_type_hastype(track, x, t):
     """Infer the return type of hastype."""
     def ismyiatype(x):  # noqa: D400
         """Type"""
-        return x is TypeType()
+        return x is TypeType
 
     await track.check(ismyiatype, t)
-    return Bool()
+    return Bool
 
 
 @type_inferrer(P.bool_not, nargs=1)
 async def infer_type_bool_not(track, x):
     """Infer the return type of not."""
     await track.will_check(Bool, x)
-    return Bool()
+    return Bool
 
 
 @type_inferrer(P.bool_and, nargs=2)
 async def infer_type_bool_and(track, x, y):
     """Infer the return type of bool_and."""
     await track.will_check(Bool, x, y)
-    return Bool()
+    return Bool
 
 
 @type_inferrer(P.bool_or, nargs=2)
 async def infer_type_bool_or(track, x, y):
     """Infer the return type of bool_or."""
     await track.will_check(Bool, x, y)
-    return Bool()
+    return Bool
 
 
 @type_inferrer(P.scalar_eq, P.scalar_ne, nargs=2)
 async def infer_type_generic_compare(track, x, y):
     """Infer the return type of a generic comparison operator."""
     await track.will_check(Number, x, y)
-    return Bool()
+    return Bool
 
 
 @type_inferrer(P.scalar_lt, P.scalar_gt, P.scalar_le, P.scalar_ge, nargs=2)
 async def infer_type_arith_compare(track, x, y):
     """Infer the return type of an arithmetic comparison operator."""
     await track.will_check(Number, x, y)
-    return Bool()
+    return Bool
 
 
 @type_inferrer(P.scalar_uadd, P.scalar_usub, nargs=1)
@@ -252,7 +252,7 @@ async def infer_type_arith_bin(track, x, y):
 async def infer_type_shape(track, ary):
     """Infer the return type of shape."""
     shp = await ary['shape']
-    return Tuple([UInt(64)]*len(shp))
+    return Tuple[[UInt[64]]*len(shp)]
 
 
 @type_inferrer(P.array_map, nargs=2)
@@ -261,7 +261,7 @@ async def infer_type_array_map(track, fn, ary):
     fn_t = await fn['type']
     ary_t = await track.check(Array, ary)
     xref = track.engine.vref({'type': ary_t.elements})
-    return Array(await fn_t(xref))
+    return Array[await fn_t(xref)]
 
 
 @type_inferrer(P.array_map2, nargs=3)
@@ -271,7 +271,7 @@ async def infer_type_array_map2(track, fn, ary1, ary2):
     ary1_t, ary2_t = await track.check(Array, ary1, ary2)
     xref = track.engine.vref({'type': ary1_t.elements})
     yref = track.engine.vref({'type': ary2_t.elements})
-    return Array(await fn_t(xref, yref))
+    return Array[await fn_t(xref, yref)]
 
 
 @type_inferrer(P.array_reduce, nargs=3)
@@ -283,7 +283,7 @@ async def infer_type_reduce(track, fn, ary, shp):
     xref = track.engine.vref({'type': ary_t.elements})
     xref2 = track.engine.vref({'type': ary_t.elements})
     res_elem_t = await fn_t(xref, xref2)
-    return Array(res_elem_t)
+    return Array[res_elem_t]
 
 
 @type_inferrer(P.array_scan, nargs=4)
@@ -296,11 +296,11 @@ async def infer_type_across_array(track, fn, init, ary, ax):
     if not ary_t.elements == init_t:
         raise MyiaTypeError("Initial value must have the same type "
                             "as array elements")
-    if not ax_t == UInt(64):
+    if not ax_t == UInt[64]:
         raise MyiaTypeError("Axis must be u64")
     xref = track.engine.vref({'type': ary_t.elements})
     xref2 = track.engine.vref({'type': ary_t.elements})
-    return Array(await fn_t(xref, xref2))
+    return Array[await fn_t(xref, xref2)]
 
 
 @type_inferrer(P.distribute, nargs=2)
@@ -338,7 +338,7 @@ async def infer_type_list_map(track, f, xs):
     xs_t = await track.check(List, xs)
     xref = track.engine.vref(dict(type=xs_t.element_type))
     ret_t = await f_t(xref)
-    return List(ret_t)
+    return List[ret_t]
 
 
 @type_inferrer(P.identity, nargs=1)
@@ -378,7 +378,7 @@ async def infer_type_iter(track, xs):
     """Infer the return type of iter."""
     xs_t = await xs['type']
     if ismyiatype(xs_t, List):
-        return Tuple([Int(64), xs_t])
+        return Tuple[Int[64], xs_t]
     else:
         raise MyiaTypeError('Unsupported type for iter')
 
@@ -390,7 +390,7 @@ async def infer_type_hasnext(track, it):
     if ismyiatype(it_t, Tuple, generic=False) \
             and len(it_t.elements) == 2 \
             and ismyiatype(it_t.elements[1], List, generic=False):
-        return Bool()
+        return Bool
     else:  # pragma: no cover
         raise MyiaTypeError('Unsupported iterator type for hasnext')
 
@@ -403,7 +403,7 @@ async def infer_type_next(track, it):
             and len(it_t.elements) == 2 \
             and ismyiatype(it_t.elements[1], List, generic=False):
         x_t = it_t.elements[1].element_type
-        return Tuple([x_t, it_t])
+        return Tuple[x_t, it_t]
     else:  # pragma: no cover
         raise MyiaTypeError('Unsupported iterator type for next')
 
@@ -412,7 +412,7 @@ async def infer_type_next(track, it):
 async def infer_type_scalar_to_array(track, x):
     """Infer the return type of scalar_to_array."""
     x_t = await track.check(Number, x)
-    return Array(x_t)
+    return Array[x_t]
 
 
 @type_inferrer(P.broadcast_shape, nargs=2)
@@ -421,7 +421,7 @@ async def infer_type_broadcast_shape(track, xs, ys):
     xs_t, ys_t = await track.check(_shape_type, xs, ys)
     shp_xs_n = len(xs_t.elements)
     shp_ys_n = len(ys_t.elements)
-    return Tuple([UInt(64) for i in range(max(shp_xs_n, shp_ys_n))])
+    return Tuple[[UInt[64] for i in range(max(shp_xs_n, shp_ys_n))]]
 
 
 @type_inferrer(P.make_record, nargs=None)
@@ -430,11 +430,11 @@ async def infer_type_make_record(track, cls, *elems):
     elem_types = [await x['type'] for x in elems]
     cls_v = await cls['value']
 
-    ret_t = Class(
+    ret_t = Class[
         cls_v.tag,
         dict(zip(cls_v.attributes.keys(), elem_types)),
         cls_v.methods
-    )
+    ]
 
     if not hastype_helper(ret_t, cls_v):
         raise MyiaTypeError(

--- a/myia/prim/value_inferrers.py
+++ b/myia/prim/value_inferrers.py
@@ -137,7 +137,7 @@ class ValueTrack(Track):
             recinf = PrimitiveValueInferrer(self, p, self.implementations[p])
             typ = pytype_to_myiatype(v)
             vref = self.engine.vref({'value': limited(typ, self.max_depth),
-                                     'type': TypeType()})
+                                     'type': TypeType})
             return PartialInferrer(self, recinf, [vref])
         elif v is ANYTHING:
             return v

--- a/myia/specialize.py
+++ b/myia/specialize.py
@@ -18,7 +18,7 @@ INACCESSIBLE = Named('INACCESSIBLE')
 
 class _Unspecializable(Exception):
     def __init__(self, problem):
-        problem = Problem(problem)
+        problem = Problem[problem]
         super().__init__(problem)
         self.problem = problem
 
@@ -98,9 +98,9 @@ async def _concretize_type(t, argrefs=None):
                 argrefs = await _find_argrefs(t)
             except _Unspecializable as e:
                 return e.args[0]
-        return Function([await _extract_type(argref)
+        return Function[[await _extract_type(argref)
                          for argref in argrefs],
-                        await _concretize_type(t.cache[tuple(argrefs)]))
+                        await _concretize_type(t.cache[tuple(argrefs)])]
     else:
         return await reify(t)
 
@@ -177,10 +177,10 @@ class _GraphSpecializer:
         sub_build = await self.build(None, all_argrefs, inf.fn)
         ptl_args = [await self.build(ref) for ref in inf.args]
         res_t = await _concretize_type(inf, argrefs)
-        ptl = _const(P.partial, Function(
+        ptl = _const(P.partial, Function[
             [sub_build.type, *[a.type for a in ptl_args]],
             res_t
-        ))
+        ])
         res = self.new_graph.apply(
             ptl,
             sub_build,

--- a/myia/utils/__init__.py
+++ b/myia/utils/__init__.py
@@ -8,7 +8,7 @@ from .merge import (  # noqa
 from .misc import (  # noqa
     Named, UNKNOWN, Registry, repr_, list_str, TypeMap, StructuralMap, smap,
     Event, Events, NS, Namespace, ModuleNamespace, ClosureNamespace, eprint,
-    is_dataclass_type
+    is_dataclass_type, as_frozen
 )
 
 from .partial import (  # noqa

--- a/myia/utils/misc.py
+++ b/myia/utils/misc.py
@@ -415,3 +415,13 @@ def eprint(*things):
 def is_dataclass_type(cls):
     """Returns whether cls is a dataclass."""
     return isinstance(cls, type) and hasattr(cls, '__dataclass_fields__')
+
+
+def as_frozen(x):
+    """Return an immutable representation for x."""
+    if isinstance(x, dict):
+        return tuple((k, as_frozen(v)) for k, v in x.items())
+    elif isinstance(x, (list, tuple)):
+        return tuple(as_frozen(y) for y in x)
+    else:
+        return x

--- a/myia/utils/misc.py
+++ b/myia/utils/misc.py
@@ -420,7 +420,7 @@ def is_dataclass_type(cls):
 def as_frozen(x):
     """Return an immutable representation for x."""
     if isinstance(x, dict):
-        return tuple((k, as_frozen(v)) for k, v in x.items())
+        return tuple(sorted((k, as_frozen(v)) for k, v in x.items()))
     elif isinstance(x, (list, tuple)):
         return tuple(as_frozen(y) for y in x)
     else:

--- a/tests/ir/test_anf.py
+++ b/tests/ir/test_anf.py
@@ -54,11 +54,11 @@ def test_graph_type():
     x = g.add_parameter()
     y = g.add_parameter()
     assert g.type is UNKNOWN
-    x.type = Int(16)
-    y.type = Float(32)
+    x.type = Int[16]
+    y.type = Float[32]
     g.output = g.apply('mul', x, y)
-    g.output.type = Float(64)
-    assert g.type == Function((Int(16), Float(32)), Float(64))
+    g.output.type = Float[64]
+    assert g.type == Function[(Int[16], Float[32]), Float[64]]
 
 
 def test_graph_output():

--- a/tests/prim/test_py_implementations.py
+++ b/tests/prim/test_py_implementations.py
@@ -133,7 +133,7 @@ def test_prim_typeof():
     assert typeof(object()) == External(object)
 
 
-def test_prim_istype():
+def test_prim_ismyiatype():
     i64 = Int(64)
     f64 = Float(64)
     assert hastype(123, i64)

--- a/tests/prim/test_py_implementations.py
+++ b/tests/prim/test_py_implementations.py
@@ -122,30 +122,30 @@ def test_prim_setattr():
 
 
 def test_prim_typeof():
-    i64 = Int(64)
-    f64 = Float(64)
+    i64 = Int[64]
+    f64 = Float[64]
     assert typeof(1) == i64
     assert typeof(1.2) == f64
-    assert typeof((1, 2.0, (3, 4))) == Tuple(i64, f64, Tuple(i64, i64))
-    assert typeof([1, 2]) == List(i64)
+    assert typeof((1, 2.0, (3, 4))) == Tuple[i64, f64, Tuple[i64, i64]]
+    assert typeof([1, 2]) == List[i64]
     with pytest.raises(TypeError):
         typeof([1, 2, 3.4])
-    assert typeof(object()) == External(object)
+    assert typeof(object()) == External[object]
 
 
 def test_prim_ismyiatype():
-    i64 = Int(64)
-    f64 = Float(64)
+    i64 = Int[64]
+    f64 = Float[64]
     assert hastype(123, i64)
     assert not hastype(123.4, i64)
     assert hastype(123.4, f64)
     assert hastype([1, 2, 3], List)
-    assert hastype([1, 2, 3], List(i64))
+    assert hastype([1, 2, 3], List[i64])
     assert hastype((1, 2.0, (3, 4)), Tuple)
-    assert hastype((1, 2.0, (3, 4)), Tuple(i64, f64, Tuple(i64, i64)))
+    assert hastype((1, 2.0, (3, 4)), Tuple[i64, f64, Tuple[i64, i64]])
     with pytest.raises(TypeError):
         hastype([1, 2, 3.4], List)
-    assert hastype(object(), External(object))
+    assert hastype(object(), External[object])
 
 
 def test_prim_shape():

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -16,48 +16,48 @@ class Point:
         return (self.x ** 2 + self.y ** 2) ** 0.5
 
 
-# def test_instantiate():
-#     with pytest.raises(RuntimeError):
-#         Type()
+def test_instantiate():
+    with pytest.raises(RuntimeError):
+        Object()
+    with pytest.raises(RuntimeError):
+        Int[64]()
 
 
 def test_cache():
-    f32 = Float(32)
-    assert f32 is Float(32)
-    assert f32 is not Float(16)
-    assert f32 is not Float(64)
+    f32 = Float[32]
+    assert f32 is Float[32]
+    assert f32 is not Float[16]
+    assert f32 is not Float[64]
 
 
 def test_Number():
-    assert issubclass(Int(32), Number)
-    assert not issubclass(Bool(), Number)
-    with pytest.raises(TypeError):
-        Number()
+    assert ismyiatype(Int[32], Number)
+    assert not ismyiatype(Bool, Number)
     with pytest.raises(ValueError):
-        Float(33)
+        Float[33]
 
 
 def test_List():
-    ll = List(Bool())
-    assert ll.element_type is Bool()
+    ll = List[Bool]
+    assert ll.element_type is Bool
 
 
 def test_Tuple():
-    t = Tuple((Float(64), Int(8), Bool()))
-    assert t.elements[1] is Int(8)
-    t1 = Tuple((Bool(), Int(8)))
-    t2 = Tuple([Bool(), Int(8)])
+    t = Tuple[Float[64], Int[8], Bool]
+    assert t.elements[1] is Int[8]
+    t1 = Tuple[(Bool, Int[8])]
+    t2 = Tuple[[Bool, Int[8]]]
     assert t1 == t2
     assert t1 is t2
-    t3 = Tuple(Bool(), Int(8))
+    t3 = Tuple[Bool, Int[8]]
     assert t1 is t3
-    assert Tuple(Float(16)) is Tuple((Float(16),))
+    assert Tuple[Float[16]] is Tuple[(Float[16],)]
 
 
 def test_Function():
-    c = Function((), Float(32))
-    assert c.retval is Float(32)
-    c2 = Function([], Float(32))
+    c = Function[(), Float[32]]
+    assert c.retval is Float[32]
+    c2 = Function[[], Float[32]]
     assert c is c2
 
 
@@ -114,42 +114,42 @@ def test_get_generic():
 
 
 def test_repr():
-    t = UInt(16)
+    t = UInt[16]
     assert repr(t) == 'UInt[16]'
 
 
 def test_type_conversions():
-    assert np_dtype_to_type('float32') is Float(32)
+    assert np_dtype_to_type('float32') is Float[32]
 
     with pytest.raises(TypeError):
         np_dtype_to_type('float80')
 
-    assert type_to_np_dtype(Float(16)) == 'float16'
+    assert type_to_np_dtype(Float[16]) == 'float16'
 
     with pytest.raises(TypeError):
-        type_to_np_dtype(List(Int(64)))
+        type_to_np_dtype(List[Int[64]])
 
 
 def test_pytype_to_myiatype():
     ptm = pytype_to_myiatype
 
     assert ptm(Int) is Int
-    assert ptm(Int(64)) is Int(64)
+    assert ptm(Int[64]) is Int[64]
 
-    assert ptm(bool) is Bool()
-    assert ptm(int) is Int(64)
-    assert ptm(float) is Float(64)
+    assert ptm(bool) is Bool
+    assert ptm(int) is Int[64]
+    assert ptm(float) is Float[64]
 
     assert ptm(tuple) is Tuple
-    assert ptm(tuple, (1, (2, 3))) is Tuple(Int(64), Tuple(Int(64), Int(64)))
+    assert ptm(tuple, (1, (2, 3))) is Tuple[Int[64], Tuple[Int[64], Int[64]]]
 
     assert ptm(list) is List
-    assert ptm(list, [1, 2, 3]) is List(Int(64))
+    assert ptm(list, [1, 2, 3]) is List[Int[64]]
     with pytest.raises(TypeError):
         ptm(list, [1, (2, 3)])
 
     assert ptm(numpy.ndarray) is Array
-    assert ptm(numpy.ndarray, numpy.ones((2, 2))) is Array(Float(64))
+    assert ptm(numpy.ndarray, numpy.ones((2, 2))) is Array[Float[64]]
 
     # We run this before ptm(Point) to make sure it doesn't cache Float, Float
     # for the type of x and y
@@ -163,7 +163,7 @@ def test_pytype_to_myiatype():
 
     pcls2 = ptm(Point, Point(1, 2))
     assert pcls2.tag is pcls.tag
-    assert pcls2.attributes == {'x': Int(64), 'y': Int(64)}
+    assert pcls2.attributes == {'x': Int[64], 'y': Int[64]}
 
-    assert ptm(str) is External(str)
-    assert ptm(object) is External(object)
+    assert ptm(str) is External[str]
+    assert ptm(object) is External[object]

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -25,35 +25,35 @@ from myia.utils import RestrictedVar
 from .test_lang import mysum, Point
 
 
-B = Bool()
+B = Bool
 
-i16 = Int(16)
-i32 = Int(32)
-i64 = Int(64)
+i16 = Int[16]
+i32 = Int[32]
+i64 = Int[64]
 
-u64 = UInt(64)
+u64 = UInt[64]
 
-f16 = Float(16)
-f32 = Float(32)
-f64 = Float(64)
+f16 = Float[16]
+f32 = Float[32]
+f64 = Float[64]
 
-li16 = L(Int(16))
-li32 = L(Int(32))
-li64 = L(Int(64))
+li16 = L[Int[16]]
+li32 = L[Int[32]]
+li64 = L[Int[64]]
 
-lf16 = L(Float(16))
-lf32 = L(Float(32))
-lf64 = L(Float(64))
+lf16 = L[Float[16]]
+lf32 = L[Float[32]]
+lf64 = L[Float[64]]
 
-ai16 = A(i16)
-ai32 = A(i32)
-ai64 = A(i64)
+ai16 = A[i16]
+ai32 = A[i32]
+ai64 = A[i64]
 
-af16 = A(f16)
-af32 = A(f32)
-af64 = A(f64)
+af16 = A[f16]
+af32 = A[f32]
+af64 = A[f64]
 
-Nil = T()
+Nil = T[()]
 
 
 Point_t = pytype_to_myiatype(Point)
@@ -61,9 +61,9 @@ Point_t = pytype_to_myiatype(Point)
 
 @dataclass(frozen=True)
 class Point3D:
-    x: Int(64)
-    y: Int(64)
-    z: Int(64)
+    x: Int[64]
+    y: Int[64]
+    z: Int[64]
 
     def abs(self):
         return (self.x ** 2 + self.y ** 2 + self.z ** 2) ** 0.5
@@ -143,7 +143,7 @@ class _to_i64:
         return int(x)
 
     async def infer_type(track, x):
-        return Int(64)
+        return Int[64]
 
 
 # Unification tricks
@@ -394,7 +394,7 @@ def test_for(xs, y):
     return rval
 
 
-@infer(type=(i64, f64, T(i64, f64)))
+@infer(type=(i64, f64, T[i64, f64]))
 def test_nullary_closure(x, y):
     def make(z):
         def inner():
@@ -405,7 +405,7 @@ def test_nullary_closure(x, y):
     return a(), b()
 
 
-@infer(type=(i64, f64, T(i64, f64)))
+@infer(type=(i64, f64, T[i64, f64]))
 def test_merge_point(x, y):
     def mul2():
         return scalar_mul
@@ -437,22 +437,22 @@ def test_too_many_args(x, y):
     return g(x, y)
 
 
-@infer(type=(i64, f64, T(i64, f64)))
+@infer(type=(i64, f64, T[i64, f64]))
 def test_tup(x, y):
     return (x, y)
 
 
-@infer(type=[(T(i64, f64), i64),
-             (T(f64, i64), f64),
-             (T(), InferenceError),
+@infer(type=[(T[i64, f64], i64),
+             (T[f64, i64], f64),
+             (T[()], InferenceError),
              (f64, InferenceError)])
 def test_head_tuple(tup):
     return head(tup)
 
 
-@infer(type=[(T(i64, f64), T(f64)),
-             (T(f64, i64), T(i64)),
-             (T(), InferenceError),
+@infer(type=[(T[i64, f64], T[f64]),
+             (T[f64, i64], T[i64]),
+             (T[()], InferenceError),
              (f64, InferenceError)])
 def test_tail_tuple(tup):
     return tail(tup)
@@ -469,14 +469,14 @@ def test_getitem_tuple(x, y):
         (lf64, i64, f64),
         (lf64, f64, InferenceError),
         (f64, i64, InferenceError),
-        (T(i64, f64), i64, InferenceError)
+        (T[i64, f64], i64, InferenceError)
     ]
 )
 def test_getitem_list(xs, i):
     return xs[i]
 
 
-@infer(type=(i64, f64, T(i64, f64)))
+@infer(type=(i64, f64, T[i64, f64]))
 def test_multitype_function(x, y):
     def mul(a, b):
         return a * b
@@ -492,9 +492,9 @@ def test_closure(x, y):
 
 @infer(
     type=[
-        (i64, i64, i64, i64, T(i64, i64)),
-        (f64, f64, f64, f64, T(f64, f64)),
-        (i64, i64, f64, f64, T(i64, f64)),
+        (i64, i64, i64, i64, T[i64, i64]),
+        (f64, f64, f64, f64, T[f64, f64]),
+        (i64, i64, f64, f64, T[i64, f64]),
         (i64, f64, f64, f64, InferenceError),
         (i64, i64, i64, f64, InferenceError),
     ]
@@ -694,7 +694,7 @@ def test_hof_2(c, x):
 
 @infer(
     type=[
-        (i64, T(T(i64, i64), T(B, B)))
+        (i64, T[T[i64, i64], T[B, B]])
     ]
 )
 def test_hof_3(x):
@@ -715,7 +715,7 @@ def test_hof_3(x):
     type=[
         (i64, i64, InferenceError),
         ({'value': -1}, i64, i64),
-        ({'value': 1}, i64, T(i64, i64)),
+        ({'value': 1}, i64, T[i64, i64]),
     ]
 )
 def test_hof_4(x, y):
@@ -869,7 +869,7 @@ def test_cover_limitedvalue_eq(x, y):
 
 @infer(
     type=[
-        (li64, lf64, T(li64, lf64)),
+        (li64, lf64, T[li64, lf64]),
         (li64, f64, InferenceError),
     ]
 )
@@ -893,19 +893,19 @@ def test_hastype_simple(x):
 @infer(
     type=[
         (i64, i64, InferenceError),
-        (i64, {'type': TypeType(), 'value': Int(64)}, B),
+        (i64, {'type': TypeType, 'value': Int[64]}, B),
     ],
     value=[
         ({'type': i64, 'value': ANYTHING},
-         {'type': TypeType(), 'value': ANYTHING}, InferenceError),
+         {'type': TypeType, 'value': ANYTHING}, InferenceError),
         ({'type': i64, 'value': ANYTHING},
-         {'type': TypeType(), 'value': i64}, {'value': True}),
+         {'type': TypeType, 'value': i64}, {'value': True}),
         ({'type': f64, 'value': ANYTHING},
-         {'type': TypeType(), 'value': i64}, {'value': False}),
-        ({'type': T(i64, i64), 'value': ANYTHING},
-         {'type': TypeType(), 'value': T(i64, i64)}, {'value': True}),
-        ({'type': T(i64, i64), 'value': ANYTHING},
-         {'type': TypeType(), 'value': T(Number, Number)}, {'value': True}),
+         {'type': TypeType, 'value': i64}, {'value': False}),
+        ({'type': T[i64, i64], 'value': ANYTHING},
+         {'type': TypeType, 'value': T[i64, i64]}, {'value': True}),
+        ({'type': T[i64, i64], 'value': ANYTHING},
+         {'type': TypeType, 'value': T[Number, Number]}, {'value': True}),
     ]
 )
 def test_hastype(x, y):
@@ -913,7 +913,7 @@ def test_hastype(x, y):
 
 
 @infer(
-    type=[(i64, TypeType())],
+    type=[(i64, TypeType)],
     value=[({'type': i64}, i64),
            ({'type': f64}, f64)]
 )
@@ -925,10 +925,10 @@ def test_typeof(x):
     type=[
         (i64, i64),
         (f64, i64),
-        (T(i64, i64), i64),
-        (T(i64, T(f64, i64)), i64),
+        (T[i64, i64], i64),
+        (T[i64, T[f64, i64]], i64),
         (li64, f64),
-        (T(i64, li64), i64),
+        (T[i64, li64], i64),
         (Point_t, i64),
         (Point3D_t, i64),
     ],
@@ -1000,7 +1000,7 @@ data = SimpleNamespace(
 
 @infer(
     type=[
-        (i64, i64, T(i64, i64)),
+        (i64, i64, T[i64, i64]),
         (i64, f64, InferenceError),
     ],
     value=[
@@ -1016,8 +1016,8 @@ def test_getattr(x, y):
 
 @infer(
     type=[
-        (i64, i64, T(i64, i64)),
-        (i64, f64, T(i64, f64)),
+        (i64, i64, T[i64, i64]),
+        (i64, f64, T[i64, f64]),
     ]
 )
 def test_getattr_multitype(x, y):
@@ -1043,7 +1043,7 @@ _getattr = getattr
         ({'value': 'add'}, i64, i64),
         ({'value': 'bad'}, i64, InferenceError),
         ({'value': 1234}, i64, InferenceError),
-        (External(str), i64, InferenceError),
+        (External[str], i64, InferenceError),
     ]
 )
 def test_getattr_flex(name, x):
@@ -1051,8 +1051,8 @@ def test_getattr_flex(name, x):
 
 
 @infer(type=[
-    (External(SimpleNamespace),
-     {'type': External(str), 'value': 'surprise'},
+    (External[SimpleNamespace],
+     {'type': External[str], 'value': 'surprise'},
      InferenceError)
 ])
 def test_unknown_data(data, field):
@@ -1101,7 +1101,7 @@ def test_infinite_mutual_recursion(x):
     return ping()
 
 
-@infer(type=[({'shape': (2, 3), 'type': ai16}, T(u64, u64))],
+@infer(type=[({'shape': (2, 3), 'type': ai16}, T[u64, u64])],
        value=[({'shape': (2, 3), 'type': ai16}, (2, 3)),
               ({'shape': (2, ANYTHING), 'type': ai16}, ANYTHING)])
 def test_shape(ary):
@@ -1122,16 +1122,16 @@ def test_dot(a, b):
 
 @infer(shape=[(ai32_of(4), {'value': (2, 4)}, (2, 4)),
               (ai32_of(4),
-               {'type': T(u64, u64)},
+               {'type': T[u64, u64]},
                (ANYTHING, ANYTHING)),
               (ai32_of(4), {'value': (5, 2)},
                InferenceError),
               ({'type': ai32, 'shape': (4, 2)}, {'value': (4,)},
                InferenceError)],
        type=[
-           (i32, {'value': (4,), 'type': T(u64)}, InferenceError),
-           (ai32_of(1), {'value': (4,), 'type': T(u64)}, ai32),
-           (li32, {'value': (4,), 'type': T(u64)}, InferenceError),
+           (i32, {'value': (4,), 'type': T[u64]}, InferenceError),
+           (ai32_of(1), {'value': (4,), 'type': T[u64]}, ai32),
+           (li32, {'value': (4,), 'type': T[u64]}, InferenceError),
            (i32, {'value': (4,)}, InferenceError)
        ])
 def test_distribute(v, shp):
@@ -1139,12 +1139,12 @@ def test_distribute(v, shp):
 
 
 @infer(shape=[(af16_of(1, 2, 3), {'value': (6,)}, (6,)),
-              (af16_of(1, 2, 3), {'type': T(u64)},
+              (af16_of(1, 2, 3), {'type': T[u64]},
                (ANYTHING,)),
               (af16_of(2, 3), {'value': (7,)},
                InferenceError)],
-       type=[(af16_of(2, 3), T(u64), af16),
-             (af16_of(2, 3), T(i64),
+       type=[(af16_of(2, 3), T[u64], af16),
+             (af16_of(2, 3), T[i64],
               InferenceError)])
 def test_reshape(v, shp):
     return reshape(v, shp)
@@ -1187,9 +1187,9 @@ def test_array_scan(ary, ax):
 
 @infer(
     type=[
-        (ai64_of(7, 9), T([u64, u64]), ai64),
+        (ai64_of(7, 9), T[u64, u64], ai64),
         (ai64_of(7, 9), i64, InferenceError),
-        (i64, T([u64, u64]), InferenceError),
+        (i64, T[u64, u64], InferenceError),
     ],
     shape=[
         (ai64_of(3, 4),
@@ -1310,18 +1310,18 @@ def test_switch(c, x, y):
 @infer(type=[(i64, ai64),
              (f64, af64),
              (af64_of(9, 7), InferenceError),
-             (T([i64]), InferenceError)],
+             (T[i64], InferenceError)],
        shape=[({'type': i64}, ())])
 def test_scalar_to_array(x):
     return scalar_to_array(x)
 
 
 @infer(type=[
-    (T([u64]), T([u64]), T([u64])),
-    (T([u64, u64]), T([u64]), T([u64, u64])),
-    (T([u64]), T([u64, u64]), T([u64, u64])),
-    (T([i64]), T([u64]), InferenceError),
-    (T([u64]), T([i64]), InferenceError),
+    (T[u64], T[u64], T[u64]),
+    (T[u64, u64], T[u64], T[u64, u64]),
+    (T[u64], T[u64, u64], T[u64, u64]),
+    (T[i64], T[u64], InferenceError),
+    (T[u64], T[i64], InferenceError),
     (i64, i64, InferenceError),
 ])
 def test_broadcast_shape(xs, ys):
@@ -1330,8 +1330,8 @@ def test_broadcast_shape(xs, ys):
 
 @infer(type=[
     (i64, i64, InferenceError),
-    (F([i64], f64), i64, f64),
-    (F([f64], f64), i64, InferenceError),
+    (F[[i64], f64], i64, f64),
+    (F[[f64], f64], i64, InferenceError),
 ])
 def test_call_argument(f, x):
     return f(x)
@@ -1435,7 +1435,7 @@ def test_forced_function_type():
     def mod(self, graph):
         # Force the inferred tyoe of scalar_add to be (i64,i64)->f64
         scalar_add = graph.output.inputs[0]
-        scalar_add.inferred['type'] = F([i64, i64], f64)
+        scalar_add.inferred['type'] = F[[i64, i64], f64]
         return graph
 
     def fn(x, y):

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -465,7 +465,7 @@ def test_rec1(x):
 
 
 mysum = MultitypeGraph('mysum')
-i64 = Int(64)
+i64 = Int[64]
 
 
 @mysum.register(i64)
@@ -527,8 +527,8 @@ def test_fact(x):
 
 @dataclass(frozen=True)
 class Point:
-    x: Int(64)
-    y: Int(64)
+    x: Int[64]
+    y: Int[64]
 
     def abs(self):
         return (self.x ** 2 + self.y ** 2) ** 0.5

--- a/tests/test_specialize.py
+++ b/tests/test_specialize.py
@@ -62,7 +62,7 @@ def validate(g):
         elif not ismyiatype(node.type, Type):
             errors[node].add(f'Unknown type: {node.type}')
         elif is_apply(node):
-            expected = Function([i.type for i in node.inputs[1:]], node.type)
+            expected = Function[[i.type for i in node.inputs[1:]], node.type]
             if node.inputs[0].type != expected:
                 errors[node].add('Function/argument inconsistency')
             fn = node.inputs[0]

--- a/tests/test_specialize.py
+++ b/tests/test_specialize.py
@@ -3,7 +3,7 @@ from pytest import mark
 from collections import defaultdict
 
 from myia.api import scalar_debug_pipeline
-from myia.dtype import Function, Type, Problem, External
+from myia.dtype import Function, Type, Problem, External, ismyiatype
 from myia.debug.label import short_labeler as lbl
 from myia.graph_utils import dfs
 from myia.infer import Inferrer
@@ -50,16 +50,16 @@ def validate(g):
             errors[node].add('Type was not inferred')
         elif isinstance(node.type, Inferrer):
             errors[node].add('Uneliminated inferrer')
-        elif isinstance(node.type, Problem):
+        elif ismyiatype(node.type, Problem):
             if node.type.kind is DEAD:
                 # This one is okay if it happens, because we don't really need
                 # to infer types for dead code.
                 pass
             else:
                 errors[node].add(f'Problem type: {node.type}')
-        elif isinstance(node.type, External):
+        elif ismyiatype(node.type, External):
             errors[node].add(f'External type: {node.type}')
-        elif not isinstance(node.type, Type):
+        elif not ismyiatype(node.type, Type):
             errors[node].add(f'Unknown type: {node.type}')
         elif is_apply(node):
             expected = Function([i.type for i in node.inputs[1:]], node.type)


### PR DESCRIPTION
* Every Myia type is now an instance of `type`.
* `ismyiatype(t)` checks if `t` is a Myia type, and `ismyiatype(t, model)` additionally checks that `t` is a subclass of `model`.
* Types are parameterized with `[]`, e.g. `Int[64]` instead of `Int(64)`.
* Use `Bool` instead of `Bool()`
