### PR TITLE
@myia API

### DIFF
--- a/myia/api.py
+++ b/myia/api.py
@@ -1,11 +1,12 @@
 """User-friendly interfaces to Myia machinery."""
 
+import inspect
 import numpy as np
 from types import FunctionType
 
 from . import dtype, parser, composite as C, operations
 from .cconv import closure_convert
-from .infer import InferenceEngine
+from .infer import InferenceEngine, ANYTHING
 from .ir import Graph, clone, GraphManager
 from .opt import PatternEquilibriumOptimizer, lib as optlib
 from .pipeline import PipelineStep, PipelineResource, PipelineDefinition
@@ -14,7 +15,7 @@ from .prim.value_inferrers import ValueTrack, value_inferrer_constructors
 from .prim.type_inferrers import TypeTrack, type_inferrer_constructors
 from .prim.shape_inferrers import ShapeTrack, shape_inferrer_constructors
 from .specialize import TypeSpecializer
-from .utils import TypeMap
+from .utils import TypeMap, as_frozen
 from .vm import VM
 from .compile import step_wrap_primitives, step_compile, step_link, step_export
 
@@ -307,22 +308,29 @@ class Inferrer(PipelineStep):
         super().__init__(pipeline_init)
         self.tracks = tracks
         self.required_tracks = required_tracks
-
-    def step(self, graph, argspec):
-        """Infer types, shapes, values, etc. for the graph."""
-        engine = InferenceEngine(
+        self.engine = InferenceEngine(
             self.pipeline,
             tracks=self.tracks,
             required_tracks=self.required_tracks,
         )
 
+    def fill_in(self, argspec):
+        """Fill in argspec with values for all tracks.
+
+        The 'value' track will also be filled in even if it already exists,
+        since it needs to be wrapped for the inferrer to use it.
+        """
         for arg in argspec:
             if 'value' in arg:
                 v = arg['value']
-                for track_name, track in engine.tracks.items():
+                for track_name, track in self.engine.tracks.items():
                     if track_name not in arg or track_name == 'value':
                         arg[track_name] = track.from_value(v, None)
 
+    def step(self, graph, argspec):
+        """Infer types, shapes, values, etc. for the graph."""
+        engine = self.engine
+        self.fill_in(argspec)
         try:
             res, context = engine.run(graph, argspec)
             return {'inference_results': res,
@@ -503,3 +511,89 @@ scalar_parse = scalar_pipeline \
 scalar_debug_compile = scalar_debug_pipeline \
     .select('parse', 'resolve', 'export') \
     .make_transformer('input', 'output')
+
+
+#################
+# Top-level API #
+#################
+
+
+class MyiaFunction:
+    """Represents a function compiled by Myia.
+
+    MyiaFunction will compile the original function for every combination of
+    argument types and shapes it is given (as well as their values,
+    optionally).
+
+    Attributes:
+        fn: The root function to compile.
+        specialize_values: Set of arguments for which we should specialize the
+            function based on their values (list of argument names).
+
+    """
+
+    def __init__(self, fn, specialize_values=[]):
+        """Initialize a MyiaFunction."""
+        self.fn = fn
+        self.specialize_values = set(specialize_values)
+        self._cache = {}
+
+    def specialize(self, args):
+        """Specialize on the types of the given arguments.
+
+        Returns a Pipeline. If the argument types were seen before, returns a
+        cached version.
+        """
+        pip = standard_debug_pipeline.make()
+        inf = pip.steps.infer
+        argspec = tuple({'value': arg} for arg in args)
+        inf.fill_in(argspec)
+        argnames = inspect.getargspec(self.fn).args
+        for arg, name in zip(argspec, argnames):
+            if name not in self.specialize_values:
+                arg['value'] = ANYTHING
+        key = as_frozen(argspec)
+        if key not in self._cache:
+            res = pip(
+                input=self.fn,
+                argspec=argspec
+            )
+            if 'error' in res:
+                raise res['error']
+            self._cache[key] = res
+        return self._cache[key]
+
+    def compile(self, args):
+        """Returns a function specialized for the given args."""
+        return self.specialize(args)['output']
+
+    def __call__(self, *args):
+        """Call the function on the given args."""
+        return self.compile(args)(*args)
+
+
+def myia(fn=None, *, specialize_values=[]):
+    """Create a function using Myia's runtime.
+
+    `@myia` can be used as a simple decorator. If custom options are needed,
+    they can be provided as keyword arguments:
+
+        @myia
+        def myfun(x, y):
+            return x + y
+
+        @myia(specialize_values=['cond'])
+        def myfun2(cond, x, y):
+            return x if cond else y
+
+    Arguments:
+        fn: The Python function to convert.
+        specialize_values: Set of arguments for which we should specialize the
+            function based on their values (list of argument names).
+    """
+    if fn is None:
+        def deco(fn):
+            return MyiaFunction(fn, specialize_values)
+        return deco
+    else:
+        return MyiaFunction(fn, specialize_values)

--- a/myia/prim/value_inferrers.py
+++ b/myia/prim/value_inferrers.py
@@ -115,6 +115,8 @@ class ValueTrack(Track):
 
     def wrap(self, v):
         """Produce a LimitedValue for v, with a maximal count."""
+        if isinstance(v, LimitedValue):
+            return v
         return LimitedValue(v, self.max_depth)
 
     def default(self, values):


### PR DESCRIPTION
This adds the `@myia` decorator. Decorating a Python function transforms it into a Myia function, a callable which will compile it for any input type signature that's encountered (and cache the compiled version).
