### PR TITLE
CSE, converting make_record to make_tuple, graph validation

### DIFF
--- a/myia/api.py
+++ b/myia/api.py
@@ -438,7 +438,7 @@ step_specialize = Specializer.partial()
 
 
 step_opt = Optimizer.partial(
-    pre=[],
+    pre=[EraseClass],
     opts=[
         optlib.simplify_always_true,
         optlib.simplify_always_false,
@@ -447,7 +447,7 @@ step_opt = Optimizer.partial(
         optlib.replace_applicator,
         optlib.elim_identity,
     ],
-    post=[CSE, EraseClass],
+    post=[CSE]
 )
 
 

--- a/myia/api.py
+++ b/myia/api.py
@@ -8,7 +8,8 @@ from . import dtype, parser, composite as C, operations
 from .cconv import closure_convert
 from .infer import InferenceEngine, ANYTHING
 from .ir import Graph, clone, GraphManager
-from .opt import PatternEquilibriumOptimizer, lib as optlib, CSE
+from .opt import PatternEquilibriumOptimizer, lib as optlib, CSE, \
+    EraseClass
 from .pipeline import PipelineStep, PipelineResource, PipelineDefinition
 from .prim import py_implementations, vm_implementations, ops as P
 from .prim.value_inferrers import ValueTrack, value_inferrer_constructors
@@ -446,7 +447,7 @@ step_opt = Optimizer.partial(
         optlib.replace_applicator,
         optlib.elim_identity,
     ],
-    post=[CSE],
+    post=[CSE, EraseClass],
 )
 
 

--- a/myia/api.py
+++ b/myia/api.py
@@ -6,6 +6,8 @@ from types import FunctionType
 
 from . import dtype, parser, composite as C, operations
 from .cconv import closure_convert
+from .dtype import Tuple, List, Class, Array, Int, Float, Bool, \
+    Number, tag_to_dataclass, ismyiatype, type_to_np_dtype
 from .infer import InferenceEngine, ANYTHING
 from .ir import Graph, clone, GraphManager
 from .opt import PatternEquilibriumOptimizer, lib as optlib, CSE, \
@@ -407,6 +409,174 @@ class DebugVMExporter(PipelineStep):
         return {'output': self.vm.export(graph)}
 
 
+_convert_arg_map = TypeMap()
+
+
+@_convert_arg_map.register(Tuple)
+def _convert_arg_Tuple(arg, orig_t, vm_t):
+    if not isinstance(arg, tuple):
+        raise TypeError('Expected tuple')
+    oe = orig_t.elements
+    ve = vm_t.elements
+    if len(arg) != len(ve):
+        raise TypeError(f'Expected {len(ve)} elements')
+    return tuple(convert_arg(x, o, v)
+                 for x, o, v in zip(arg, oe, ve))
+
+
+@_convert_arg_map.register(List)
+def _convert_arg_List(arg, orig_t, vm_t):
+    if not isinstance(arg, list):
+        raise TypeError('Expected list')
+    ot = orig_t.element_type
+    vt = vm_t.element_type
+    return [convert_arg(x, ot, vt) for x in arg]
+
+
+@_convert_arg_map.register(Class)
+def _convert_arg_Class(arg, orig_t, vm_t):
+    # If the EraseClass opt was applied, vm_t may be Tuple
+    dc = tag_to_dataclass[orig_t.tag]
+    if not isinstance(arg, dc):
+        raise TypeError(f'Expected {dc.__qualname__}')
+    arg = tuple(getattr(arg, attr) for attr in orig_t.attributes)
+    oe = list(orig_t.attributes.values())
+    vm_is_tup = ismyiatype(vm_t, Tuple)
+    if vm_is_tup:
+        ve = vm_t.elements
+    else:
+        ve = vm_t.attributes.values()
+    tup = tuple(convert_arg(x, o, v)
+                for x, o, v in zip(arg, oe, ve))
+    if vm_is_tup:
+        return tup
+    else:
+        return dc(*tup)
+
+
+@_convert_arg_map.register(Array)
+def _convert_arg_Array(arg, orig_t, vm_t):
+    if not isinstance(arg, np.ndarray):
+        raise TypeError('Expected ndarray')
+    et = orig_t.elements
+    assert ismyiatype(et, Number)
+    dtype = type_to_np_dtype(et)
+    if arg.dtype != dtype:
+        raise TypeError('Wrong dtype')
+    return arg
+
+
+@_convert_arg_map.register(Int)
+def _convert_arg_Int(arg, orig_t, vm_t):
+    if not isinstance(arg, int):
+        raise TypeError(f'Expected int')
+    return arg
+
+
+@_convert_arg_map.register(Float)
+def _convert_arg_Float(arg, orig_t, vm_t):
+    if not isinstance(arg, float):
+        raise TypeError(f'Expected float')
+    return arg
+
+
+@_convert_arg_map.register(Bool)
+def _convert_arg_Bool(arg, orig_t, vm_t):
+    if not isinstance(arg, bool):
+        raise TypeError(f'Expected bool')
+    return arg
+
+
+def convert_arg(arg, orig_t, vm_t):
+    """Check that arg matches orig_t, and convert to vm_t."""
+    return _convert_arg_map[orig_t](arg, orig_t, vm_t)
+
+
+_convert_result_map = TypeMap()
+
+
+@_convert_result_map.register(Class)
+def _convert_result_Class(res, orig_t, vm_t):
+    dc = tag_to_dataclass[orig_t.tag]
+    oe = orig_t.attributes.values()
+    ve = vm_t.attributes.values()
+    tup = tuple(convert_result(getattr(res, attr), o, v)
+                for attr, o, v in zip(orig_t.attributes, oe, ve))
+    return dc(*tup)
+
+
+@_convert_result_map.register(List)
+def _convert_result_List(res, orig_t, vm_t):
+    ot = orig_t.element_type
+    vt = vm_t.element_type
+    return [convert_result(x, ot, vt) for x in res]
+
+
+@_convert_result_map.register(Tuple)
+def _convert_result_Tuple(res, orig_t, vm_t):
+    # If the EraseClass opt was applied, orig_t may be Class
+    orig_is_class = ismyiatype(orig_t, Class)
+    if orig_is_class:
+        oe = orig_t.attributes.values()
+    else:
+        oe = orig_t.elements
+    ve = vm_t.elements
+    tup = tuple(convert_result(x, o, v)
+                for x, o, v in zip(res, oe, ve))
+    if orig_is_class:
+        dc = tag_to_dataclass[orig_t.tag]
+        return dc(*tup)
+    else:
+        return tup
+
+
+@_convert_result_map.register(Int)
+@_convert_result_map.register(Float)
+@_convert_result_map.register(Bool)
+@_convert_result_map.register(Array)
+def _convert_result_leaf(arg, orig_t, vm_t):
+    return arg
+
+
+def convert_result(res, orig_t, vm_t):
+    """Convert result from vm_t to orig_t."""
+    return _convert_result_map[vm_t](res, orig_t, vm_t)
+
+
+class OutputWrapper(PipelineStep):
+    """Pipeline step to convert to and from the VM's data format.
+
+    For example, dataclasses in the arguments may be converted to
+    tuples, and tuples returned by the VM would be converted back
+    to the appropriate dataclasses, as determined by Myia.
+
+    Inputs:
+        graph: The root graph.
+        output: The callable returned by the VM.
+        argspec: Contains the original types/etc. of the arguments.
+        inference_results: Contains the original return type.
+
+    Outputs:
+        output: The wrapped callable.
+    """
+
+    def step(self, graph, output, argspec, inference_results):
+        """Convert args to vm format, and output from vm format."""
+        fn = output
+        orig_arg_t = [arg['type'] for arg in argspec]
+        vm_arg_t = graph.type.arguments
+        orig_out_t = inference_results['type']
+        vm_out_t = graph.type.retval
+
+        def wrapped(*args):
+            args = tuple(convert_arg(arg, ot, vt) for arg, ot, vt in
+                         zip(args, orig_arg_t, vm_arg_t))
+            res = fn(*args)
+            res = convert_result(res, orig_out_t, vm_out_t)
+            return res
+        return {'output': wrapped}
+
+
 step_parse = Parser.partial()
 
 
@@ -459,6 +629,9 @@ step_debug_export = DebugVMExporter.partial(
 )
 
 
+step_wrap = OutputWrapper.partial()
+
+
 _standard_pipeline = PipelineDefinition(
     resources=dict(
         manager=GraphManager.partial(),
@@ -490,11 +663,15 @@ standard_pipeline = _standard_pipeline \
         wrap_primitives=step_wrap_primitives,
         compile=step_compile,
         link=step_link,
-        export=step_export
+        export=step_export,
+        wrap=step_wrap,
     )
 
 standard_debug_pipeline = _standard_pipeline \
-    .insert_after(export=step_debug_export)
+    .insert_after(
+        export=step_debug_export,
+        wrap=step_wrap,
+    )
 
 
 scalar_pipeline = standard_pipeline.configure({

--- a/myia/api.py
+++ b/myia/api.py
@@ -8,7 +8,7 @@ from . import dtype, parser, composite as C, operations
 from .cconv import closure_convert
 from .infer import InferenceEngine, ANYTHING
 from .ir import Graph, clone, GraphManager
-from .opt import PatternEquilibriumOptimizer, lib as optlib
+from .opt import PatternEquilibriumOptimizer, lib as optlib, CSE
 from .pipeline import PipelineStep, PipelineResource, PipelineDefinition
 from .prim import py_implementations, vm_implementations, ops as P
 from .prim.value_inferrers import ValueTrack, value_inferrer_constructors
@@ -446,7 +446,7 @@ step_opt = Optimizer.partial(
         optlib.replace_applicator,
         optlib.elim_identity,
     ],
-    post=[],
+    post=[CSE],
 )
 
 

--- a/myia/api.py
+++ b/myia/api.py
@@ -530,10 +530,7 @@ def _convert_result_Tuple(res, orig_t, vm_t):
         return tup
 
 
-@_convert_result_map.register(Int)
-@_convert_result_map.register(Float)
-@_convert_result_map.register(Bool)
-@_convert_result_map.register(Array)
+@_convert_result_map.register(Int, Float, Bool, Array)
 def _convert_result_leaf(arg, orig_t, vm_t):
     return arg
 

--- a/myia/ir/anf.py
+++ b/myia/ir/anf.py
@@ -256,7 +256,13 @@ class ANFNode(Node):
 
     def is_apply(self) -> bool:
         """Return whether self is an Apply."""
-        return isinstance(self, Apply)
+        if isinstance(x, Apply):
+            if value is not None:
+                fn = x.inputs[0]
+                return is_constant(fn) and fn.value is value
+            else:
+                return True
+        return False
 
     def is_parameter(self) -> bool:
         """Return whether self is a Parameter."""

--- a/myia/ir/anf.py
+++ b/myia/ir/anf.py
@@ -254,12 +254,12 @@ class ANFNode(Node):
     # Checks #
     ##########
 
-    def is_apply(self) -> bool:
+    def is_apply(self, value: Any = None) -> bool:
         """Return whether self is an Apply."""
-        if isinstance(x, Apply):
+        if isinstance(self, Apply):
             if value is not None:
-                fn = x.inputs[0]
-                return is_constant(fn) and fn.value is value
+                fn = self.inputs[0]
+                return fn.is_constant() and fn.value is value
             else:
                 return True
         return False

--- a/myia/ir/manager.py
+++ b/myia/ir/manager.py
@@ -581,6 +581,7 @@ class GraphManager(Partializable):
 
         for g in dropped:
             self.events.drop_graph(g)
+            self.all_nodes -= set(g.parameters)
             self.graphs.remove(g)
             if g._manager is self:
                 g._manager = None
@@ -652,8 +653,8 @@ class GraphManager(Partializable):
             if node not in self.all_nodes:
                 continue
             uses = self.uses[node]
-            if uses or node.is_parameter():
-                # This node is still live
+
+            if uses or (is_parameter(node) and node in node.graph.parameters):
                 continue
 
             if node.is_constant_graph():

--- a/myia/ir/manager.py
+++ b/myia/ir/manager.py
@@ -654,7 +654,7 @@ class GraphManager(Partializable):
                 continue
             uses = self.uses[node]
 
-            if uses or (is_parameter(node) and node in node.graph.parameters):
+            if uses or (node.is_parameter() and node in node.graph.parameters):
                 continue
 
             if node.is_constant_graph():

--- a/myia/opt/__init__.py
+++ b/myia/opt/__init__.py
@@ -6,3 +6,7 @@ from .opt import (  # noqa
     pattern_replacer,
     PatternEquilibriumOptimizer
 )
+
+from .cse import (  # noqa
+    cse, CSE
+)

--- a/myia/opt/__init__.py
+++ b/myia/opt/__init__.py
@@ -10,3 +10,7 @@ from .opt import (  # noqa
 from .cse import (  # noqa
     cse, CSE
 )
+
+from .clean import (  # noqa
+    EraseClass
+)

--- a/myia/opt/clean.py
+++ b/myia/opt/clean.py
@@ -1,0 +1,88 @@
+"""Clean up Class types."""
+
+from ..dtype import Tuple, List, Class, Function, Type, ismyiatype
+from ..ir import is_apply
+from ..prim import ops as P
+from ..utils import TypeMap
+
+
+_retype_map = TypeMap()
+
+
+@_retype_map.register(Tuple)
+def _retype_Tuple(t):
+    return Tuple[[_retype(t2) for t2 in t.elements]]
+
+
+@_retype_map.register(List)
+def _retype_List(t):
+    return List[_retype(t.element_type)]
+
+
+@_retype_map.register(Class)
+def _retype_Class(t):
+    return Tuple[[_retype(t2) for t2 in t.attributes.values()]]
+
+
+@_retype_map.register(Function)
+def _retype_Function(t):
+    return Function[[_retype(t2) for t2 in t.arguments], _retype(t.retval)]
+
+
+@_retype_map.register(Type)
+def _retype_Type(t):
+    return t
+
+
+@_retype_map.register(object)
+def _retype_object(t):
+    return t
+
+
+def _retype(t):
+    if not ismyiatype(t):
+        t = type(t)
+    return _retype_map[t](t)
+
+
+def erase_class(root, manager):
+    """Remove the Class type from graphs.
+
+    * Class[x: t, ...] => Tuple[t, ...]
+    * getattr(data, attr) => getitem(data, idx)
+    * make_record(cls, *args) => make_tuple(*args)
+    """
+    manager.add_graph(root)
+
+    for node in list(manager.all_nodes):
+        new_node = None
+
+        if is_apply(node, P.getattr):
+            _, data, item = node.inputs
+            dt = data.type
+            assert ismyiatype(dt, Class)
+            idx = list(dt.attributes.keys()).index(item.value)
+            new_node = node.graph.apply(P.tuple_getitem, data, idx)
+
+        elif is_apply(node, P.make_record):
+            _, typ, *args = node.inputs
+            new_node = node.graph.apply(P.make_tuple, *args)
+
+        if new_node is not None:
+            new_node.type = node.type
+            manager.replace(node, new_node)
+
+    for node in manager.all_nodes:
+        node.type = _retype(node.type)
+
+
+class EraseClass:
+    """Remove the Class type from graphs."""
+
+    def __init__(self, optimizer):
+        """Initialize EraseClass."""
+        self.optimizer = optimizer
+
+    def __call__(self, root):
+        """Remove the Class type from graphs."""
+        erase_class(root, self.optimizer.resources.manager)

--- a/myia/opt/clean.py
+++ b/myia/opt/clean.py
@@ -1,7 +1,7 @@
 """Clean up Class types."""
 
 from ..dtype import Int, Tuple, List, Class, Function, Type, ismyiatype
-from ..ir import is_apply, is_constant, Constant
+from ..ir import Constant
 from ..prim import ops as P
 from ..utils import TypeMap
 
@@ -61,7 +61,7 @@ def erase_class(root, manager):
     for node in list(manager.all_nodes):
         new_node = None
 
-        if is_apply(node, P.getattr):
+        if node.is_apply(P.getattr):
             _, data, item = node.inputs
             dt = data.type
             assert ismyiatype(dt, Class)
@@ -72,14 +72,14 @@ def erase_class(root, manager):
             gi.type = Function[[dt, Int[64]], node.type]
             new_node = node.graph.apply(gi, data, idx)
 
-        elif is_apply(node, P.make_record):
+        elif node.is_apply(P.make_record):
             mkr, typ, *args = node.inputs
             mkt = _mkr_to_mkt(mkr)
             new_node = node.graph.apply(mkt, *args)
 
-        elif is_apply(node, P.partial):
+        elif node.is_apply(P.partial):
             orig_ptl, oper, *args = node.inputs
-            if is_constant(oper) and oper.value is P.make_record:
+            if oper.is_constant() and oper.value is P.make_record:
                 argtypes = [arg.type for arg in args[1:]]
                 mkt = _mkr_to_mkt(oper)
                 if len(args) == 1:

--- a/myia/opt/cse.py
+++ b/myia/opt/cse.py
@@ -1,0 +1,70 @@
+"""Common subexpression elimination."""
+
+
+from collections import defaultdict
+
+from ..graph_utils import toposort
+from ..ir import succ_incoming, is_constant, is_apply, is_parameter
+
+
+def cse(root, manager):
+    """Apply CSE on root."""
+    hashes = {}
+    groups = defaultdict(list)
+    manager.add_graph(root)
+
+    for g in manager.graphs:
+        for node in toposort(g.return_, succ_incoming):
+            if node in hashes:
+                continue
+
+            if is_constant(node):
+                h = hash((node.value, type(node.value)))
+            elif is_apply(node):
+                h = hash(tuple(hashes[inp] for inp in node.inputs))
+            elif is_parameter(node):
+                h = hash(node)
+            else:
+                raise TypeError(f'Unknown node type: {node}') \
+                    # pragma: no cover
+
+            hashes[node] = h
+            groups[h].append(node)
+
+    # Note: this relies on dict keeping insertion order, so that the groups
+    # dict is basically topologically ordered.
+
+    for h, group in groups.items():
+        main, *others = group
+        for other in others:
+            assert main.graph is other.graph
+            if is_constant(main) and is_constant(other):
+                v1 = main.value
+                v2 = other.value
+                repl = type(v1) is type(v2) and v1 == v2
+            elif is_apply(main) and is_apply(other):
+                # The inputs to both should have been merged beforehand
+                # because groups is topologically sorted
+                in1 = main.inputs
+                in2 = other.inputs
+                repl = len(in1) == len(in2) \
+                    and all(i1 is i2 for i1, i2 in zip(in1, in2))
+            else:
+                raise AssertionError('CSE put together incompatible nodes.')
+
+            if repl:
+                manager.replace(other, main)
+
+    return root
+
+
+class CSE:
+    """Common subexpression elimination."""
+
+    def __init__(self, optimizer):
+        """Initialize CSE."""
+        self.optimizer = optimizer
+
+    def __call__(self, root):
+        """Apply CSE on root."""
+        cse(root, self.optimizer.resources.manager)

--- a/myia/opt/cse.py
+++ b/myia/opt/cse.py
@@ -4,7 +4,7 @@
 from collections import defaultdict
 
 from ..graph_utils import toposort
-from ..ir import succ_incoming, is_constant, is_apply, is_parameter
+from ..ir import succ_incoming
 
 
 def cse(root, manager):
@@ -18,11 +18,11 @@ def cse(root, manager):
             if node in hashes:
                 continue
 
-            if is_constant(node):
+            if node.is_constant():
                 h = hash((node.value, type(node.value)))
-            elif is_apply(node):
+            elif node.is_apply():
                 h = hash(tuple(hashes[inp] for inp in node.inputs))
-            elif is_parameter(node):
+            elif node.is_parameter():
                 h = hash(node)
             else:
                 raise TypeError(f'Unknown node type: {node}') \
@@ -38,11 +38,11 @@ def cse(root, manager):
         main, *others = group
         for other in others:
             assert main.graph is other.graph
-            if is_constant(main) and is_constant(other):
+            if main.is_constant() and other.is_constant():
                 v1 = main.value
                 v2 = other.value
                 repl = type(v1) is type(v2) and v1 == v2
-            elif is_apply(main) and is_apply(other):
+            elif main.is_apply() and other.is_apply():
                 # The inputs to both should have been merged beforehand
                 # because groups is topologically sorted
                 in1 = main.inputs

--- a/myia/opt/cse.py
+++ b/myia/opt/cse.py
@@ -42,10 +42,7 @@ def cse(root, manager):
                 continue  # pragma: no cover
 
             elif main.is_constant() and other.is_constant():
-                v1 = main.value
-                v2 = other.value
-                # repl = type(v1) is type(v2) and v1 == v2
-                repl = main.type is other.type and v1 == v2
+                repl = main.type is other.type and main.value == other.value
 
             elif main.is_apply() and other.is_apply():
                 # The inputs to both should have been merged beforehand

--- a/myia/utils/merge.py
+++ b/myia/utils/merge.py
@@ -74,13 +74,9 @@ def _cleanup_dict(d):
     return type(d)({k: cleanup(v) for k, v in d.items() if v is not DELETE})
 
 
+@_cleanup_map.register(tuple, list, set)
 def _cleanup_sequence(xs):
     return type(xs)(cleanup(x) for x in xs)
-
-
-_cleanup_map.register(tuple, _cleanup_sequence)
-_cleanup_map.register(list, _cleanup_sequence)
-_cleanup_map.register(set, _cleanup_sequence)
 
 
 def cleanup(x):

--- a/myia/utils/misc.py
+++ b/myia/utils/misc.py
@@ -103,18 +103,13 @@ class TypeMap(dict):
         super().__init__(*args)
         self.discover = discover
 
-    def register(self, obj_t, handler=None):
-        """Register a handler to the given type.
-
-        This method may be used as a decorator.
-        """
-        if handler is None:
-            def deco(fn):
-                self[obj_t] = fn
-                return fn
-            return deco
-        else:
-            self[obj_t] = handler
+    def register(self, *obj_ts):
+        """Decorator to register a handler to the given types."""
+        def deco(handler):
+            for obj_t in obj_ts:
+                self[obj_t] = handler
+            return handler
+        return deco
 
     def __missing__(self, obj_t):
         """Get the handler for the given type."""

--- a/myia/validate.py
+++ b/myia/validate.py
@@ -1,0 +1,180 @@
+"""Validate that a graph has been cleaned up and is ready for optimization."""
+
+from .dtype import Tuple, List, Class, Function, Type, Number, Bool, \
+    Problem, ismyiatype
+from .ir import is_apply, is_constant, manage
+from .prim import Primitive, ops as P
+from .specialize import DEAD
+from .utils import TypeMap
+
+
+class ValidationError(Exception):
+    """Error validating a Graph."""
+
+
+_validate_type_map = TypeMap()
+
+
+@_validate_type_map.register(Tuple)
+def _validate_type_Tuple(t):
+    for t2 in t.elements:
+        _validate_type(t2)
+
+
+@_validate_type_map.register(List)
+def _validate_type_List(t):
+    _validate_type(t.element_type)
+
+
+@_validate_type_map.register(Class)
+def _validate_type_Class(t):
+    raise ValidationError(f'Illegal type in the graph: {t}')
+
+
+@_validate_type_map.register(Function)
+def _validate_type_Function(t):
+    for t2 in t.arguments:
+        _validate_type(t2)
+    _validate_type(t.retval)
+
+
+@_validate_type_map.register(Problem)
+def _validate_type_Problem(t):
+    if t.kind != DEAD:
+        raise ValidationError(f'Illegal type in the graph: {t}')
+
+
+@_validate_type_map.register(Bool)
+@_validate_type_map.register(Number)
+def _validate_type_Number(t):
+    pass
+
+
+@_validate_type_map.register(Type)
+def _validate_type_Type(t):
+    raise ValidationError(f'Illegal type in the graph: {t}')
+
+
+def _validate_type(t):
+    if not ismyiatype(t):
+        raise ValidationError(f'Illegal type in the graph: {t}')
+    return _validate_type_map[t](t)
+
+
+# All the legal operations are listed here.
+# Illegal ones are commented out.
+whitelist = frozenset({
+    P.scalar_add,
+    P.scalar_sub,
+    P.scalar_mul,
+    P.scalar_div,
+    P.scalar_mod,
+    P.scalar_pow,
+    P.scalar_uadd,
+    P.scalar_usub,
+    P.scalar_eq,
+    P.scalar_lt,
+    P.scalar_gt,
+    P.scalar_ne,
+    P.scalar_le,
+    P.scalar_ge,
+    P.bool_not,
+    P.bool_and,
+    P.bool_or,
+    # P.typeof,
+    # P.hastype,
+    P.make_tuple,
+    P.tail,
+    P.tuple_getitem,
+    P.list_getitem,
+    P.array_getitem,
+    P.tuple_setitem,
+    P.list_setitem,
+    P.array_setitem,
+    # P.getattr,
+    # P.setattr,
+    P.tuple_len,
+    P.list_len,
+    P.array_len,
+    P.scalar_to_array,
+    P.broadcast_shape,
+    P.shape,
+    P.array_map,
+    P.array_scan,
+    P.array_reduce,
+    P.distribute,
+    P.reshape,
+    P.dot,
+    P.if_,
+    P.switch,
+    P.return_,
+    P.list_map,
+    P.identity,
+    # P.resolve,
+    P.partial,
+    # P.make_record,
+})
+
+
+class Validator:
+    """Verify that g is properly type-specialized.
+
+    Every node of each graph must have a concrete type in its type attribute,
+    every application must be compatible with its argument types, and every
+    primitive must belong to the whitelist.
+    """
+
+    def __init__(self, root, whitelist):
+        """Initialize and run the Validator."""
+        self.errors = []
+        self.whitelist = frozenset(whitelist)
+        self._run(root)
+
+    def _test(self, node, fn):
+        try:
+            fn(node)
+        except ValidationError as err:
+            err.node = node
+            self.errors.append(err)
+
+    def _validate_type(self, node):
+        return _validate_type(node.type)
+
+    def _validate_oper(self, node):
+        if is_constant(node, Primitive):
+            if node.value not in self.whitelist:
+                raise ValidationError(f'Illegal primitive: {node.value}')
+
+    def _validate_consistency(self, node):
+        if is_apply(node):
+            expected = Function[[i.type for i in node.inputs[1:]], node.type]
+            # _validate_consistency(node.inputs)
+            actual = node.inputs[0].type
+            if actual != expected:
+                raise ValidationError(
+                    f'Function/argument inconsistency: Expected {expected}, '
+                    f'Got {actual}.'
+                )
+
+    def _run(self, root):
+        manager = manage(root)
+        for node in list(manager.all_nodes):
+            self._test(node, self._validate_type)
+            self._test(node, self._validate_oper)
+            self._test(node, self._validate_consistency)
+        if self.errors:
+            errset = {f'* {err.args[0]}' for err in self.errors}
+            errlist = "\n".join(sorted(errset))
+            err = ValidationError(f'The graph is not valid:\n\n{errlist}')
+            err.errors = self.errors
+            raise err
+
+
+def validate(root, whitelist=whitelist):
+    """Verify that g is properly type-specialized.
+
+    Every node of each graph must have a concrete type in its type attribute,
+    every application must be compatible with its argument types, and every
+    primitive must belong to the whitelist.
+    """
+    Validator(root, whitelist)

--- a/myia/validate.py
+++ b/myia/validate.py
@@ -2,7 +2,7 @@
 
 from .dtype import Tuple, List, Class, Function, Type, Number, Bool, \
     Problem, ismyiatype
-from .ir import is_apply, is_constant, manage
+from .ir import manage
 from .prim import Primitive, ops as P
 from .specialize import DEAD
 from .utils import TypeMap
@@ -141,12 +141,12 @@ class Validator:
         return _validate_type(node.type)
 
     def _validate_oper(self, node):
-        if is_constant(node, Primitive):
+        if node.is_constant(Primitive):
             if node.value not in self.whitelist:
                 raise ValidationError(f'Illegal primitive: {node.value}')
 
     def _validate_consistency(self, node):
-        if is_apply(node):
+        if node.is_apply():
             expected = Function[[i.type for i in node.inputs[1:]], node.type]
             # _validate_consistency(node.inputs)
             actual = node.inputs[0].type

--- a/myia/validate.py
+++ b/myia/validate.py
@@ -1,6 +1,6 @@
 """Validate that a graph has been cleaned up and is ready for optimization."""
 
-from .dtype import Tuple, List, Class, Function, Type, Number, Bool, \
+from .dtype import Tuple, List, Function, Type, Number, Bool, \
     Problem, ismyiatype
 from .ir import manage
 from .prim import Primitive, ops as P
@@ -26,11 +26,6 @@ def _validate_type_List(t):
     _validate_type(t.element_type)
 
 
-@_validate_type_map.register(Class)
-def _validate_type_Class(t):
-    raise ValidationError(f'Illegal type in the graph: {t}')
-
-
 @_validate_type_map.register(Function)
 def _validate_type_Function(t):
     for t2 in t.arguments:
@@ -38,15 +33,8 @@ def _validate_type_Function(t):
     _validate_type(t.retval)
 
 
-@_validate_type_map.register(Problem)
-def _validate_type_Problem(t):
-    if t.kind != DEAD:
-        raise ValidationError(f'Illegal type in the graph: {t}')
-
-
-@_validate_type_map.register(Bool)
-@_validate_type_map.register(Number)
-def _validate_type_Number(t):
+@_validate_type_map.register(Number, Bool, Problem[DEAD])
+def _validate_type_OK(t):
     pass
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,81 @@
+
+from dataclasses import dataclass
+from myia.dtype import Bool, Int, UInt, Float, List, Array, Tuple, Function, \
+    pytype_to_myiatype
+from myia.ir import MultitypeGraph
+
+
+B = Bool
+L = List
+A = Array
+T = Tuple
+F = Function
+
+i16 = Int[16]
+i32 = Int[32]
+i64 = Int[64]
+
+u64 = UInt[64]
+
+f16 = Float[16]
+f32 = Float[32]
+f64 = Float[64]
+
+li16 = L[Int[16]]
+li32 = L[Int[32]]
+li64 = L[Int[64]]
+
+lf16 = L[Float[16]]
+lf32 = L[Float[32]]
+lf64 = L[Float[64]]
+
+ai16 = A[i16]
+ai32 = A[i32]
+ai64 = A[i64]
+
+af16 = A[f16]
+af32 = A[f32]
+af64 = A[f64]
+
+Nil = T[()]
+
+
+@dataclass(frozen=True)
+class Point:
+    x: i64
+    y: i64
+
+    def abs(self):
+        return (self.x ** 2 + self.y ** 2) ** 0.5
+
+
+@dataclass(frozen=True)
+class Point3D:
+    x: i64
+    y: i64
+    z: i64
+
+    def abs(self):
+        return (self.x ** 2 + self.y ** 2 + self.z ** 2) ** 0.5
+
+
+Point_t = pytype_to_myiatype(Point)
+Point3D_t = pytype_to_myiatype(Point3D)
+
+
+mysum = MultitypeGraph('mysum')
+
+
+@mysum.register(i64)
+def _mysum1(x):
+    return x
+
+
+@mysum.register(i64, i64)
+def _mysum2(x, y):
+    return x + y
+
+
+@mysum.register(i64, i64, i64)
+def _mysum3(x, y, z):
+    return x + y + z

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -7,9 +7,8 @@ from types import SimpleNamespace
 
 from myia.api import scalar_pipeline, standard_pipeline
 from myia.debug.traceback import print_inference_error
-from myia.dtype import Array as A, Bool, Int, Float, Tuple as T, List as L, \
-    Function as F, TypeType, UInt, External, pytype_to_myiatype, Number, \
-    Class
+from myia.dtype import Array as A, Int, Float, TypeType, External, \
+    Number, Class
 from myia.hypermap import HyperMap
 from myia.infer import \
     ANYTHING, InferenceError, register_inferrer

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from pytest import mark
 from types import SimpleNamespace
-from dataclasses import dataclass
 
 from myia.api import scalar_pipeline, standard_pipeline
 from myia.debug.traceback import print_inference_error
@@ -27,58 +26,13 @@ from myia.prim.py_implementations import \
     tuple_setitem, list_setitem
 from myia.utils import RestrictedVar
 
-from .test_lang import mysum, Point
-
-
-B = Bool
-
-i16 = Int[16]
-i32 = Int[32]
-i64 = Int[64]
-
-u64 = UInt[64]
-
-f16 = Float[16]
-f32 = Float[32]
-f64 = Float[64]
-
-li16 = L[Int[16]]
-li32 = L[Int[32]]
-li64 = L[Int[64]]
-
-lf16 = L[Float[16]]
-lf32 = L[Float[32]]
-lf64 = L[Float[64]]
-
-ai16 = A[i16]
-ai32 = A[i32]
-ai64 = A[i64]
-
-af16 = A[f16]
-af32 = A[f32]
-af64 = A[f64]
-
-Nil = T[()]
+from .common import B, T, L, F, i16, i32, i64, u64, f32, f64, \
+    li32, li64, lf64, ai16, ai32, ai64, af16, af32, af64, Nil, \
+    Point, Point_t, Point3D, Point3D_t, mysum
 
 
 def t(tt):
     return {'type': tt}
-
-
-Point_t = pytype_to_myiatype(Point)
-
-
-@dataclass(frozen=True)
-class Point3D:
-    x: Int[64]
-    y: Int[64]
-    z: Int[64]
-
-    def abs(self):
-        return (self.x ** 2 + self.y ** 2 + self.z ** 2) ** 0.5
-
-
-Point3D_t = pytype_to_myiatype(Point3D)
 
 
 def ai64_of(*shp):

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -1,13 +1,11 @@
 
 from copy import copy
-from types import SimpleNamespace
-from dataclasses import dataclass
-
 from pytest import mark
+from types import SimpleNamespace
 
 from myia.api import standard_debug_pipeline
-from myia.dtype import Int
-from myia.ir import MultitypeGraph
+
+from .common import mysum, Point
 
 
 lang_pipeline = standard_debug_pipeline \
@@ -464,25 +462,6 @@ def test_rec1(x):
 #############
 
 
-mysum = MultitypeGraph('mysum')
-i64 = Int[64]
-
-
-@mysum.register(i64)
-def _mysum1(x):
-    return x
-
-
-@mysum.register(i64, i64)
-def _mysum2(x, y):
-    return x + y
-
-
-@mysum.register(i64, i64, i64)
-def _mysum3(x, y, z):
-    return x + y + z
-
-
 @parse_compare((2, 3, 4))
 def test_multitype(x, y, z):
     return mysum(x) * mysum(x, y) * mysum(x, y, z)
@@ -523,15 +502,6 @@ def test_fact(x):
         else:
             return n * fact(n - 1)
     return fact(x)
-
-
-@dataclass(frozen=True)
-class Point:
-    x: Int[64]
-    y: Int[64]
-
-    def abs(self):
-        return (self.x ** 2 + self.y ** 2) ** 0.5
 
 
 @parse_compare(42)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,132 @@
+
+import pytest
+
+from myia.api import scalar_pipeline, scalar_parse
+from myia.prim import ops as P
+from myia.prim.py_implementations import make_record, partial, list_map
+from myia.validate import validate as _validate, ValidationError
+from myia.opt.clean import erase_class
+
+from .common import L, i64, Point, Point_t
+
+
+test_whitelist = frozenset({
+    P.scalar_add,
+    P.scalar_sub,
+    P.scalar_mul,
+    P.scalar_div,
+    P.make_tuple,
+    P.tuple_getitem,
+    P.list_map,
+    P.partial,
+    P.if_,
+    P.return_,
+})
+
+
+def validate(g):
+    return _validate(g, whitelist=test_whitelist)
+
+
+pip = scalar_pipeline \
+    .select('parse', 'infer', 'specialize')
+
+
+def make(*types):
+    def deco(fn):
+        res = pip.run(input=fn, argspec=[{'type': t} for t in types])
+        if 'error' in res:
+            raise res['error']
+        return res['graph']
+    return deco
+
+
+def valid(*types):
+    def deco(fn):
+        g = make(*types)(fn)
+        validate(g)
+    return deco
+
+
+def invalid(*types):
+    def deco(fn):
+        g = make(*types)(fn)
+        with pytest.raises(ValidationError):
+            validate(g)
+    return deco
+
+
+def valid_after_ec(*types):
+    def deco(fn):
+        g = make(*types)(fn)
+        with pytest.raises(ValidationError):
+            validate(g)
+        erase_class(g, g.manager)
+        validate(g)
+    return deco
+
+
+def test_validate():
+    @valid(i64, i64)
+    def f1(x, y):
+        return x + y
+
+    # ** is not in the whitelist
+    @invalid(i64, i64)
+    def f2(x, y):
+        return x ** y
+
+    # make_record is not in the whitelist
+    # erase_class should remove it
+    @valid_after_ec(i64, i64)
+    def f3(x, y):
+        return Point(x, y)
+
+    @valid()
+    def f4():
+        return 123
+
+    # Cannot have String types
+    @invalid()
+    def f5():
+        return "hello"
+
+    @valid(i64, i64)
+    def f6(x, y):
+        return x.__add__(y)
+
+    # Cannot have Class types
+    # erase_class should remove it
+    @valid_after_ec(Point_t)
+    def f7(pt):
+        return pt
+
+    # Cannot have getattr
+    # erase_class should remove it
+    @valid_after_ec(Point_t)
+    def f8(pt):
+        return pt.x
+
+    @scalar_parse
+    def f9(x):
+        return x
+
+    with pytest.raises(ValidationError):
+        validate(f9)
+
+
+def test_clean():
+
+    @valid_after_ec(i64, i64)
+    def f1(x, y):
+        return make_record(Point_t, x, y)
+
+    @valid_after_ec(i64, i64)
+    def f2(x, y):
+        return partial(make_record, Point_t, x)(y)
+
+    @valid_after_ec(L[Point_t])
+    def f3(xs):
+        def f(pt):
+            return pt.x + pt.y
+        return list_map(f, xs)

--- a/tests/utils/test_misc.py
+++ b/tests/utils/test_misc.py
@@ -14,8 +14,8 @@ def _sum(*args):
 
 def test_typemap():
     tmap = TypeMap()
-    tmap.register(int, 'int')
-    tmap.register(object, 'obj')
+    tmap.register(int)('int')
+    tmap.register(object)('obj')
     assert tmap[int] == 'int'
     assert tmap[str] == 'obj'
 


### PR DESCRIPTION
## Additions

* Add common subexpression elimination.
* Add an "optimization" pass that maps `Class`, `make_record` and `getattr` to `Tuple`, `make_tuple` and `getitem`.
* Add a pipeline step after `export` that converts records from the arguments given by the user into tuples, and converts tuples in the output back into the appropriate classes, so that it is all transparent.
* Add `Validator`, which checks that the graph only contains approved types and approved primitives.

## Fixes

* Fix a bug in the manager that led to parameters from removed graphs remaining in `all_nodes`.
* Fix a bug in the specializer whereas the wrong graphs were sometimes cloned.
