### PR TITLE
More inference fixes, working MLP

### DIFF
--- a/myia/api.py
+++ b/myia/api.py
@@ -1,6 +1,7 @@
 """User-friendly interfaces to Myia machinery."""
 
 import inspect
+import math
 import numpy as np
 from types import FunctionType
 
@@ -59,6 +60,11 @@ scalar_object_map = {
     operations.next: C.next,
     operations.to_array: C.to_array,
     operations.if_: P.if_,
+    math.exp: P.scalar_exp,
+    math.log: P.scalar_log,
+    math.sin: P.scalar_sin,
+    math.cos: P.scalar_cos,
+    math.tan: P.scalar_tan,
 }
 
 
@@ -98,6 +104,22 @@ standard_object_map = {
     operations.next: C.next,
     operations.to_array: C.to_array,
     operations.if_: P.if_,
+    math.exp: P.scalar_exp,
+    math.log: P.scalar_log,
+    math.sin: P.scalar_sin,
+    math.cos: P.scalar_cos,
+    math.tan: P.scalar_tan,
+    np.add: C.add,
+    np.subtract: C.sub,
+    np.multiply: C.mul,
+    np.divide: C.div,
+    np.mod: C.mod,
+    np.power: C.pow,
+    np.exp: C.exp,
+    np.log: C.log,
+    np.sin: C.sin,
+    np.cos: C.cos,
+    np.tan: C.tan,
 }
 
 
@@ -200,7 +222,8 @@ standard_method_map = TypeMap({
 
 
 @overload
-def lax_convert(env, fn: FunctionType):
+def default_convert(env, fn: FunctionType):
+    """Default converter for Python types."""
     g = clone(parser.parse(fn))
     env.resources.manager.add_graph(g)
     env.object_map[fn] = g
@@ -208,12 +231,12 @@ def lax_convert(env, fn: FunctionType):
 
 
 @overload  # noqa: F811
-def lax_convert(env, seq: (tuple, list)):
+def default_convert(env, seq: (tuple, list)):
     return type(seq)(env(x) for x in seq)
 
 
 @overload  # noqa: F811
-def lax_convert(env, x: (object, type, TypeMeta)):
+def default_convert(env, x: (object, type, TypeMeta)):
     return x
 
 
@@ -653,7 +676,7 @@ _standard_pipeline = PipelineDefinition(
         method_map=standard_method_map,
         convert=Converter.partial(
             object_map=standard_object_map,
-            converter=lax_convert
+            converter=default_convert
         ),
     ),
     steps=dict(

--- a/myia/api.py
+++ b/myia/api.py
@@ -7,7 +7,7 @@ from types import FunctionType
 from . import dtype, parser, composite as C, operations
 from .cconv import closure_convert
 from .dtype import Tuple, List, Class, Array, Int, Float, Bool, \
-    Number, tag_to_dataclass, ismyiatype, type_to_np_dtype
+    Number, tag_to_dataclass, ismyiatype, type_to_np_dtype, TypeMeta
 from .infer import InferenceEngine, ANYTHING
 from .ir import Graph, clone, GraphManager
 from .opt import PatternEquilibriumOptimizer, lib as optlib, CSE, \
@@ -220,6 +220,7 @@ lax_type_map = TypeMap({
     list: _convert_sequence,
     object: _convert_identity,
     type: _convert_identity,
+    TypeMeta: _convert_identity,
 })
 
 

--- a/myia/dtype.py
+++ b/myia/dtype.py
@@ -106,6 +106,19 @@ class TypeMeta(type):
             args = f'[{", ".join([repr(a) for a in cls._params.values()])}]'
         return f'{name}{args}'
 
+    def __visit__(cls, fn):
+        """Visit function for unification purposes."""
+        if cls.is_generic():
+            fn(id(cls))
+            return cls
+        else:
+            fn(cls.generic)
+            args = {}
+            if cls._params:
+                for k, v in cls._params.items():
+                    args[k] = fn(v)
+            return cls.generic.make_subtype(**args)
+
 
 class Type(metaclass=TypeMeta):
     """Base class for all Types."""

--- a/myia/infer/core.py
+++ b/myia/infer/core.py
@@ -437,12 +437,12 @@ async def reify_shallow(x: ValueWrapper):
 
 @overload  # noqa: F811
 async def reify_shallow(v: Var):
-    return await v._infvar
+    return await reify_shallow(v._infvar)
 
 
 @overload  # noqa: F811
 async def reify_shallow(v: InferenceVar):
-    return await v
+    return await reify_shallow(await v)
 
 
 @overload  # noqa: F811

--- a/myia/infer/core.py
+++ b/myia/infer/core.py
@@ -423,3 +423,28 @@ async def reify(v: TypeMeta):
 @overload  # noqa: F811
 async def reify(v: (type, object)):
     return v
+
+
+@overload
+async def reify_shallow(x: ValueWrapper):
+    """Build a concrete value from v.
+
+    Unlike reify which is deep, the outermost InferenceVar will be
+    awaited on.
+    """
+    return await reify_shallow(x.value)
+
+
+@overload  # noqa: F811
+async def reify_shallow(v: Var):
+    return await v._infvar
+
+
+@overload  # noqa: F811
+async def reify_shallow(v: InferenceVar):
+    return await v
+
+
+@overload  # noqa: F811
+async def reify_shallow(v: (type, object)):
+    return v

--- a/myia/infer/core.py
+++ b/myia/infer/core.py
@@ -446,5 +446,5 @@ async def reify_shallow(v: InferenceVar):
 
 
 @overload  # noqa: F811
-async def reify_shallow(v: (type, object)):
+async def reify_shallow(v: (type, object, TypeMeta)):
     return v

--- a/myia/infer/core.py
+++ b/myia/infer/core.py
@@ -343,10 +343,6 @@ class InferenceVar(asyncio.Future):
         self.loop.equiv[self.var] = result
         super().set_result(result)
 
-    async def __reify__(self):
-        """Map this InferenceVar to a concrete value."""
-        return await reify(await self)
-
 
 async def find_coherent_result(infv, fn):
     """Try to apply fn on infv, resolving it only if needed.
@@ -366,7 +362,7 @@ async def find_coherent_result(infv, fn):
     return await fn(x)
 
 
-@overload(fallback_method='__reify__')
+@overload
 async def reify(x: ValueWrapper):
     """Build a concrete value from v.
 
@@ -378,6 +374,11 @@ async def reify(x: ValueWrapper):
 @overload  # noqa: F811
 async def reify(v: Var):
     return await reify(await v._infvar)
+
+
+@overload  # noqa: F811
+async def reify(v: InferenceVar):
+    return await reify(await v)
 
 
 @overload  # noqa: F811

--- a/myia/infer/graph_infer.py
+++ b/myia/infer/graph_infer.py
@@ -463,15 +463,6 @@ class Context:
             and self.graph == other.graph \
             and self.argkey == other.argkey
 
-    async def __reify__(self):
-        """Reify this Context."""
-        return Context(
-            await reify(self.parent),
-            self.graph,
-            await reify(self.argkey),
-            True
-        )
-
 
 class AbstractReference:
     """Superclass for Reference and VirtualReference."""

--- a/myia/infer/graph_infer.py
+++ b/myia/infer/graph_infer.py
@@ -431,15 +431,12 @@ class Context:
         """Create an empty context."""
         return Context(None, None, ())
 
-    def __init__(self, parent, g, argvals, raw_argvals=False):
+    def __init__(self, parent, g, argvals):
         """Initialize the Context."""
         self.parent = parent
         self.graph = g
-        if raw_argvals:
-            self.argkey = argvals
-        else:
-            self.argkey = tuple(tuple(sorted(argv.items()))
-                                for argv in argvals)
+        self.argkey = tuple(tuple(sorted(argv.items()))
+                            for argv in argvals)
         self.parent_cache = dict(parent.parent_cache) if parent else {}
         self.parent_cache[g] = self
 

--- a/myia/infer/graph_infer.py
+++ b/myia/infer/graph_infer.py
@@ -211,7 +211,7 @@ class Track(Partializable):
         the same thing as all the other refs.
         """
         async def chk(ref):
-            res = await ref.get_shallow(self.name)
+            res = await ref[self.name]
             if not self.apply_predicate(predicate, res):
                 raise self.predicate_error(
                     predicate,
@@ -571,11 +571,6 @@ class TransformedReference(AbstractReference):
         """Get the raw value for the track."""
         track, v = await self._parent_raw(track_name)
         return self.fn(track, v)
-
-    async def get_shallow(self, track_name):
-        """Get the raw value for the track, which might be wrapped."""
-        track, v = await self._parent_raw(track_name)
-        return self.fn(track, await reify_shallow(v))
 
     async def __getitem__(self, track_name):
         if track_name == '*':

--- a/myia/operations.py
+++ b/myia/operations.py
@@ -6,7 +6,7 @@ from operator import (  # noqa
     pos, neg, not_, and_, or_, matmul, getitem, setitem
 )
 
-from math import (  # noqa
+from numpy import (  # noqa
     exp, log, sin, cos, tan
 )
 

--- a/myia/prim/inferrer_utils.py
+++ b/myia/prim/inferrer_utils.py
@@ -14,7 +14,7 @@ class MyiaAttributeError(InferenceError):
     """Raised when an attribute is not found in a type or module."""
 
 
-async def static_getter(track, data, item, fetch, chk=None):
+async def static_getter(track, data, item, fetch, on_dcattr, chk=None):
     """Return an inferrer for resolve or getattr.
 
     Arguments:
@@ -46,16 +46,7 @@ async def static_getter(track, data, item, fetch, chk=None):
     if case == 'class':
         # Get field from Class
         if item_v in data_t.attributes:
-            if track.name == 'type':
-                return data_t.attributes[item_v]
-            else:
-                data_v = await data['value']
-                if data_v is ANYTHING:
-                    return track.default({'type': data_t})
-                else:
-                    return track.from_value(
-                        getattr(data_v, item_v), Context.empty()
-                    )
+            return await on_dcattr(data, data_t, item_v)
         elif item_v in data_t.methods:
             method = data_t.methods[item_v]
             method = resources.convert(method)

--- a/myia/prim/py_implementations.py
+++ b/myia/prim/py_implementations.py
@@ -38,7 +38,7 @@ def _assert_scalar(*args):
             if x.shape != ():
                 msg = f'Expected scalar, not array with shape {x.shape}'
                 raise TypeError(msg)
-        elif not isinstance(x, (int, float)):
+        elif not isinstance(x, (int, float, np.number)):
             raise TypeError(f'Expected scalar, not {type(x)}')
 
 

--- a/myia/specialize.py
+++ b/myia/specialize.py
@@ -2,7 +2,7 @@
 
 from collections import Counter
 
-from .dtype import Type, Function, Number, Bool, Problem, TypeType
+from .dtype import Type, Function, Number, Bool, Problem, TypeType, TypeMeta
 from .infer import ANYTHING, Context, reify, \
     GraphInferrer, MetaGraphInferrer, PartialInferrer, Inferrer
 from .ir import GraphCloner, Constant
@@ -214,7 +214,8 @@ class _GraphSpecializer:
         return _const(v, await _concretize_type(inf, argrefs))
 
     @_build.register  # noqa: F811
-    async def _build(self, ref, argrefs, t: (Number, Bool, TypeType, type)):
+    async def _build(self, ref, argrefs,
+                     t: (Number, Bool, TypeType, type, TypeMeta)):
         v = await ref['value']
         if v is ANYTHING:
             return await self._build[Type](ref, argrefs, t)

--- a/myia/specialize.py
+++ b/myia/specialize.py
@@ -59,7 +59,7 @@ class TypeSpecializer:
         g = await ginf.make_graph(argrefs)
         ctx = await ginf.make_context(argrefs)
 
-        ctxkey = await reify(ctx)
+        ctxkey = ctx  # TODO: Reify ctx to collapse multiple ctx into one
         if ctxkey in self.specializations:
             return self.specializations[ctxkey]
 

--- a/myia/utils/misc.py
+++ b/myia/utils/misc.py
@@ -117,7 +117,7 @@ class TypeMap(dict):
         handler = None
 
         if issubclass(obj_t, type):
-            mro = [type]
+            mro = [obj_t]
         else:
             mro = obj_t.mro()
 

--- a/myia/validate.py
+++ b/myia/validate.py
@@ -1,6 +1,7 @@
 """Validate that a graph has been cleaned up and is ready for optimization."""
 
-from .dtype import Tuple, List, Function, Type, Number, Bool, Problem, TypeMeta
+from .dtype import Array, Tuple, List, Function, Type, Number, Bool, Problem, \
+    TypeMeta
 from .ir import manage
 from .prim import Primitive, ops as P
 from .specialize import DEAD
@@ -15,6 +16,11 @@ class ValidationError(Exception):
 def _validate_type(t: Tuple):
     for t2 in t.elements:
         _validate_type(t2)
+
+
+@overload  # noqa: F811
+def _validate_type(t: Array):
+    _validate_type(t.elements)
 
 
 @overload  # noqa: F811
@@ -60,6 +66,11 @@ whitelist = frozenset({
     P.scalar_pow,
     P.scalar_uadd,
     P.scalar_usub,
+    P.scalar_exp,
+    P.scalar_log,
+    P.scalar_sin,
+    P.scalar_cos,
+    P.scalar_tan,
     P.scalar_eq,
     P.scalar_lt,
     P.scalar_gt,

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1,7 +1,6 @@
 
 import operator
 import numpy as np
-import math
 
 from pytest import mark
 from types import SimpleNamespace
@@ -300,7 +299,7 @@ def test_prim_usub(x):
     (B, InferenceError)
 ])
 def test_prim_log(x):
-    return math.log(x)
+    return np.log(x)
 
 
 @infer(

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1634,6 +1634,7 @@ def test_max_std(x, y):
     type=[
         (f64, f64),
         (i64, i64),
+        (af32_of(2, 5), af32),
     ]
 )
 def test_add1_stdx(x):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,104 @@
+
+import numpy
+from dataclasses import dataclass
+from numpy import cast, ones as _ones, zeros as _zeros
+from numpy.random import rand as _rand
+from myia.dtype import Array, Tuple
+from myia.infer import InferenceError
+
+from .test_infer import infer_std
+from .test_specialize import specialize_std
+from .common import af32, af64
+
+
+#############
+# Utilities #
+#############
+
+
+def ones(*shp, dtype='float64'):
+    return _ones(shp, dtype=dtype)
+
+
+def zeros(*shp, dtype='float64'):
+    return _zeros(shp, dtype=dtype)
+
+
+def rand(*shp, dtype='float64'):
+    return cast[dtype](_rand(*shp) - 0.5)
+
+
+#########
+# Model #
+#########
+
+
+def tanh(x):
+    e = numpy.exp(-2 * x)
+    return (1 - e) / (1 + e)
+
+
+@dataclass(frozen=True)
+class TanhLayer:
+    W: Array
+    b: Array
+
+    def apply(self, input):
+        return tanh(input @ self.W + self.b)
+
+
+@dataclass(frozen=True)
+class Model:
+    layers: Tuple
+
+    def apply(self, x):
+        for layer in self.layers:
+            x = layer.apply(x)
+        return x
+
+
+#########
+# Tests #
+#########
+
+
+inp = rand(3, 10)
+
+
+def make_model(dtype='float64'):
+    return Model(
+        layers=(
+            TanhLayer(rand(10, 15, dtype=dtype), zeros(1, 15, dtype=dtype)),
+            TanhLayer(rand(15, 8, dtype=dtype), zeros(1, 8, dtype=dtype)),
+        )
+    )
+
+
+@infer_std(
+    type=[
+        ({'value': make_model()},
+         {'value': rand(3, 10)},
+         af64),
+        ({'value': make_model('float32')},
+         {'value': rand(3, 10)},
+         InferenceError),
+        ({'value': make_model('float32')},
+         {'value': rand(3, 10, dtype='float32')},
+         af32),
+    ],
+    shape=[
+        ({'value': make_model()},
+         {'value': rand(3, 10)},
+         (3, 8)),
+        ({'value': make_model()},
+         {'value': rand(3, 14)},
+         InferenceError),
+    ]
+)
+def test_forward_infer(model, x):
+    return model.apply(x)
+
+
+@specialize_std((make_model(), rand(3, 10)))
+def test_forward_specialize(model, x):
+    return model.apply(x)


### PR DESCRIPTION
This fixes a few more issues with inference regarding literals. The inferrer and specializer are now strong enough to support the forward pass of an MLP, which is added in `test_model`. The pipeline isn't super efficient right now, one of these tests takes about a second, but it works.
