### PR TITLE
Re-inference system

### DIFF
--- a/myia/infer/core.py
+++ b/myia/infer/core.py
@@ -187,6 +187,10 @@ class EvaluationCache:
         del self.cache[key]
         return await v
 
+    def clear(self):
+        """Clear the cache completely."""
+        self.cache.clear()
+
 
 class EquivalenceChecker:
     """Handle equivalence between values."""

--- a/myia/infer/core.py
+++ b/myia/infer/core.py
@@ -178,15 +178,6 @@ class EvaluationCache:
         fut.set_result(value)
         self.cache[key] = fut
 
-    async def invalidate(self, key):
-        """Invalidate the current key in the cache and return the old value.
-
-        Raises KeyError if the key wasn't in the cache to begin with.
-        """
-        v = self.cache[key]
-        del self.cache[key]
-        return await v
-
     def clear(self):
         """Clear the cache completely."""
         self.cache.clear()

--- a/myia/infer/graph_infer.py
+++ b/myia/infer/graph_infer.py
@@ -286,7 +286,7 @@ class Inferrer(DynamicMap):
             except Unspecializable as e:
                 return e.args[0]
         cached = self.cache[tuple(argrefs)]
-        return Function[[await concretize_type(await argref['type'])
+        return Function[[await concretize_type(await argref[self.track.name])
                          for argref in argrefs],
                         await concretize_type(cached)]
 

--- a/myia/infer/graph_infer.py
+++ b/myia/infer/graph_infer.py
@@ -487,10 +487,6 @@ class ExplicitInferrer(Inferrer):
             )
         return self.retval
 
-    async def as_function_type(self, argrefs=None):
-        """Return a Function type corresponding to this Inferrer."""
-        return Function[self.argvals, self.retval]
-
 
 def register_inferrer(*prims, nargs, constructors):
     """Define a PrimitiveInferrer for prims with nargs arguments.
@@ -803,14 +799,7 @@ class InferenceEngine:
             return await track.infer_apply(ref)
 
         else:
-            return track.default({})
-
-    def invalidate(self, track, ref):
-        """Invalidate the current key in the cache and return the old value.
-
-        Raises KeyError if the key wasn't in the cache to begin with.
-        """
-        return self.cache.invalidate((track, ref))
+            raise AssertionError(f'Missing information for {key}', key)
 
     def get_inferred(self, track, ref):
         """Get a Future for the value of the Reference on the given track.

--- a/myia/infer/graph_infer.py
+++ b/myia/infer/graph_infer.py
@@ -737,21 +737,24 @@ class InferenceEngine:
         )
         self.context_class = context_class
 
-    def run(self, graph, argvals, tracks):
+    def run(self, graph, *, tracks, argspec, outspec=None):
         """Run the inferrer on a graph given initial values.
 
         Arguments:
             graph: The graph to analyze.
-            argvals: The arguments. Must be a tuple of dictionaries where
+            tracks: The names of the tracks to infer.
+            argspec: The arguments. Must be a tuple of dictionaries where
                 each dictionary maps track name to value.
+            outspec (optional): Expected inference results. If provided,
+                inference results will be checked against them.
         """
-        argrefs = [self.vref(arg) for arg in argvals]
-        argvals = [{t: ref.values[t] for t in self.all_track_names}
+        argrefs = [self.vref(arg) for arg in argspec]
+        argspec = [{t: ref.values[t] for t in self.all_track_names}
                    for ref in argrefs]
 
         self.mng.add_graph(graph)
         empty_context = self.context_class.empty()
-        root_context = empty_context.add(graph, as_frozen(argvals))
+        root_context = empty_context.add(graph, as_frozen(argspec))
         output_ref = self.ref(graph.return_, root_context)
 
         async def _run():
@@ -761,7 +764,20 @@ class InferenceEngine:
                                     broaden=False)
                 self.loop.schedule(inf(*argrefs))
 
+        async def _check():
+            for track in tracks:
+                expected = outspec[track]
+                if expected not in (UNKNOWN, ANYTHING):
+                    self.equiv.declare_equivalent(
+                        output_ref.get_raw(track),
+                        expected,
+                        [output_ref]
+                    )
+
         self.run_coroutine(_run())
+        if outspec is not None:
+            self.run_coroutine(_check())
+
         results = {name: output_ref.get(name) for name in tracks}
         return results, root_context
 

--- a/myia/utils/misc.py
+++ b/myia/utils/misc.py
@@ -566,4 +566,6 @@ class ErrorPool:
         """Raise an exception if an error occurred."""
         if self.errors:
             msg = "\n".join(stringify(e) for e in self.errors)
-            raise self.exc_class(msg)
+            exc = self.exc_class(msg)
+            exc.errors = self.errors
+            raise exc

--- a/tests/opt/test_opt.py
+++ b/tests/opt/test_opt.py
@@ -377,63 +377,30 @@ def test_type_tracking():
         .select('parse', 'infer', 'specialize',
                 'prepare', 'opt', 'validate') \
         .configure({
-            'opt.phases.main': [opt_ok1, opt_err1, opt_err2],
-            'prepare.watch': True
+            'opt.phases.main': [opt_ok1, opt_ok2, opt_err1, opt_err2],
         })
 
-    def fn1(x, y):
+    def fn_ok1(x, y):
         return x + y
 
-    pip.run(input=fn1, argspec=({'type': i64}, {'type': i64}))
+    pip.run(input=fn_ok1, argspec=({'type': i64}, {'type': i64}))
 
-    def fn2(x, y):
+    def fn_ok2(x):
+        return -x
+
+    pip.run(input=fn_ok2, argspec=({'type': i64},))
+
+    def fn_err1(x, y):
         return x - y
 
     with pytest.raises(InferenceError):
-        pip.run(input=fn2, argspec=({'type': i64}, {'type': i64}))
+        pip.run(input=fn_err1, argspec=({'type': i64}, {'type': i64}))
 
-    def fn3(x, y):
+    def fn_err2(x, y):
         return x / y
 
     with pytest.raises(InferenceError):
-        pip.run(input=fn3, argspec=({'type': i64}, {'type': i64}))
-
-
-def test_type_tracking_reinfer():
-
-    pip = scalar_pipeline \
-        .select('parse', 'infer', 'specialize',
-                'prepare', 'opt', 'validate') \
-        .configure({
-            'opt.phases.main': [opt_ok1, opt_ok2, opt_err1, opt_err2],
-            'prepare.reinfer': True
-        })
-
-    def fn1(x, y):
-        return x + y
-
-    pip.run(input=fn1, argspec=({'type': i64}, {'type': i64}))
-
-    def fn2(x):
-        return -x
-
-    pip.run(input=fn2, argspec=({'type': i64},))
-
-    def fn3(x, y, z):
-        a = x - y
-        b = a + z
-        return b
-
-    with pytest.raises(InferenceError):
-        pip.run(input=fn3,
-                argspec=({'type': i64}, {'type': i64}, {'type': i64}))
-
-    def fn4(x, y, z):
-        return (x / y) + z
-
-    with pytest.raises(InferenceError):
-        pip.run(input=fn4,
-                argspec=({'type': f64}, {'type': f64}, {'type': f64}))
+        pip.run(input=fn_err2, argspec=({'type': i64}, {'type': i64}))
 
 
 def test_type_tracking_newgraph():
@@ -443,7 +410,6 @@ def test_type_tracking_newgraph():
                 'prepare', 'opt', 'validate') \
         .configure({
             'opt.phases.main': [opt_newg, opt_newg_bad],
-            'prepare.reinfer': True
         })
 
     def fn1(x, y):

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -135,9 +135,9 @@ infer_pipeline = scalar_pipeline.select(
     'parse', 'infer'
 ).configure({
     'py_implementations': pyimpl_test,
-    'infer.tracks.value.max_depth': 10,
-    'infer.tracks.value.constructors': value_inferrer_cons_test,
-    'infer.tracks.type.constructors': type_inferrer_cons_test,
+    'inferrer.tracks.value.max_depth': 10,
+    'inferrer.tracks.value.constructors': value_inferrer_cons_test,
+    'inferrer.tracks.type.constructors': type_inferrer_cons_test,
 })
 
 
@@ -145,9 +145,9 @@ infer_pipeline_std = standard_pipeline.select(
     'parse', 'infer'
 ).configure({
     'py_implementations': pyimpl_test,
-    'infer.tracks.value.max_depth': 10,
-    'infer.tracks.value.constructors': value_inferrer_cons_test,
-    'infer.tracks.type.constructors': type_inferrer_cons_test,
+    'inferrer.tracks.value.max_depth': 10,
+    'inferrer.tracks.value.constructors': value_inferrer_cons_test,
+    'inferrer.tracks.type.constructors': type_inferrer_cons_test,
 })
 
 
@@ -190,7 +190,7 @@ def inferrer_decorator(pipeline):
 
                 def out():
                     pip = pipeline.configure({
-                        'infer.required_tracks': required_tracks
+                        'inferrer.required_tracks': required_tracks,
                     })
 
                     res = pip.make()(input=fn, argspec=args)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -194,7 +194,7 @@ def inferrer_decorator(pipeline):
                     })
 
                     res = pip.make()(input=fn, argspec=args)
-                    rval = res['inference_results']
+                    rval = res['outspec']
 
                     print('Output of inferrer:')
                     print(rval)
@@ -1625,7 +1625,7 @@ def test_forced_type():
                     [{'type': i64}, {'type': f64}]]:
 
         results = pip.run(input=fn, argspec=argspec)
-        rval = results['inference_results']
+        rval = results['outspec']
 
         assert rval['type'] == f64
 
@@ -1650,7 +1650,7 @@ def test_forced_function_type():
         input=fn,
         argspec=[{'type': i64}, {'type': i64}]
     )
-    rval = results['inference_results']
+    rval = results['outspec']
 
     assert rval['type'] == f64
 


### PR DESCRIPTION
The current system to update inference information doesn't work too well with gradient generation right now, and until it can be redesigned, I propose to just re-run the inferrer and specializer. I've factored out some code to a new resource, `resources.inferrer=InferenceResource(...)`. `resources.inferrer.renormalize(graph, argspec, outspec)` runs inference and specialization and returns a new graph. `outspec` is just a dictionary of inferred properties for the output so that we can check that the output types don't change. I removed the live inferrer entirely for the time being.
