### PR TITLE
Add optimizations

### DIFF
--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -158,6 +158,29 @@ elim_identity = psub(
 )
 
 
+#########################
+# Array simplifications #
+#########################
+
+
+# distribute(x, shp) => x when x.shape == shp
+elim_distribute = psub(
+    pattern=(P.distribute, X, C),
+    replacement=X,
+    condition=lambda equiv: equiv[X].shape == equiv[C].value,
+    name='elim_distribute'
+)
+
+
+# array_reduce(f, x, shp) => x when x.shape == shp
+elim_array_reduce = psub(
+    pattern=(P.array_reduce, Y, X, C),
+    replacement=X,
+    condition=lambda equiv: equiv[X].shape == equiv[C].value,
+    name='elim_array_reduce'
+)
+
+
 ######################
 # Branch elimination #
 ######################

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -1,8 +1,6 @@
 """Library of optimizations."""
 
-from ..graph_utils import dfs
-from ..ir import succ_incoming, freevars_boundary, Graph, Constant, \
-    GraphCloner
+from ..ir import Graph, Constant, GraphCloner
 from ..prim import Primitive, ops as P
 from ..utils import Namespace
 from ..utils.unify import Var, var, SVar
@@ -244,19 +242,10 @@ def is_trivial_graph(g, node, args):
     A trivial graph is a graph that contains at most one function
     application.
     """
-    nodes = [node
-             for node in dfs(g.output,
-                             succ_incoming,
-                             freevars_boundary(g, False))
-             if node.is_apply()]
-
-    if len(nodes) == 0:
-        return True
-    elif len(nodes) == 1:
-        app, = nodes
-        return all(not inp.is_constant_graph() for inp in app.inputs[1:])
-    else:
-        return False
+    nodes = [node for node in g.nodes if node.is_apply()]
+    # One node will be the return node, so len(nodes) == 1 if the node
+    # returns a constant or a free variable.
+    return len(nodes) <= 2
 
 
 def is_unique_use(g, node, args):

--- a/myia/opt/opt.py
+++ b/myia/opt/opt.py
@@ -85,6 +85,7 @@ class PatternSubstitutionOptimization:
                  pattern,
                  replacement,
                  *,
+                 condition=None,
                  name=None,
                  multigraph=True):
         """Initialize va PatternSubstitutionOptimization."""
@@ -95,6 +96,7 @@ class PatternSubstitutionOptimization:
         else:
             self.replacement = sexp_to_node(replacement, g)
         self.unif = Unification()
+        self.condition = condition
         self.name = name
 
     def __call__(self, optimizer, node):
@@ -114,7 +116,7 @@ class PatternSubstitutionOptimization:
         if equiv is not None:
             if callable(self.replacement):
                 return self.replacement(optimizer, node, equiv)
-            else:
+            elif self.condition is None or self.condition(equiv):
                 return self.unif.reify(self.replacement, equiv)
         else:
             return None

--- a/myia/specialize.py
+++ b/myia/specialize.py
@@ -1,7 +1,6 @@
 """Specialize graphs according to the types of their arguments."""
 
 import numpy
-from collections import Counter
 
 from .dtype import Type, Function, Number, Bool, TypeType, TypeMeta
 from .infer import ANYTHING, Context, concretize_type, \
@@ -11,6 +10,9 @@ from .ir import GraphCloner, Constant
 from .prim import ops as P, Primitive
 from .utils import Overload, overload, Namespace, SymbolicKeyInstance, \
     EnvInstance
+
+
+_count = 0
 
 
 def _const(v, t):
@@ -29,7 +31,6 @@ class TypeSpecializer:
         self.node_map = self.mng.nodes
         self.originals = {}
         self.specializations = {}
-        self.counts = Counter()
 
     def run(self, graph, context):
         """Run the specializer on the given graph in the given context."""
@@ -52,7 +53,6 @@ class TypeSpecializer:
         if ctxkey in self.specializations:
             return self.specializations[ctxkey]
 
-        self.counts[g] += 1
         gspec = _GraphSpecializer(parent, self, g, ctx)
         g2 = gspec.new_graph
         self.originals[g2] = g
@@ -108,7 +108,9 @@ class _GraphSpecializer:
         self.context = context
         self.nodes = specializer.node_map[self.graph]
 
-        rel = f'{self.specializer.counts[self.graph]}'
+        global _count
+        _count += 1
+        rel = _count
         g = self.graph
         if self.parent:
             g = self.parent.get(g)

--- a/tests/opt/test_lib.py
+++ b/tests/opt/test_lib.py
@@ -1,6 +1,4 @@
 
-from pytest import mark
-
 from .test_opt import _check_opt
 from myia.opt import lib
 from myia.prim.py_implementations import \
@@ -445,7 +443,6 @@ def test_inline_trivial():
                lib.inline_trivial)
 
 
-@mark.xfail(reason="inline_trivial does not look into closures properly")
 def test_inline_nontrivial_through_fv():
 
     def nontrivial(x):

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1276,6 +1276,14 @@ def test_distribute(v, shp):
     return distribute(v, shp)
 
 
+@infer(type=[(ai32_of(3, 7), ai32)],
+       shape=[(ai32_of(3, 7), (3, 7)),
+              (ai32_of(7), (3, 7)),
+              (ai32_of(3), InferenceError)])
+def test_distribute2(v):
+    return distribute(v, (3, 7))
+
+
 @infer(shape=[(af16_of(1, 2, 3), {'type': T[u64], 'value': (6,)}, (6,)),
               (af16_of(1, 2, 3), {'type': T[u64]},
                (ANYTHING,)),

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1279,6 +1279,8 @@ def test_distribute(v, shp):
 @infer(type=[(ai32_of(3, 7), ai32)],
        shape=[(ai32_of(3, 7), (3, 7)),
               (ai32_of(7), (3, 7)),
+              (ai32_of(1), (3, 7)),
+              (ai32_of(1, 7), (3, 7)),
               (ai32_of(3), InferenceError)])
 def test_distribute2(v):
     return distribute(v, (3, 7))


### PR DESCRIPTION
This adds several optimization-related improvements:

* Remove distribute/array_reduce when the target shape is the same as the input's shape.
* Simplify combinations of `env_getitem`, `env_setitem`, and empty envs.
* Fix `is_trivial_graph` (an xfail now passes).
* Add a way to create conditional patterns more simply.

Also a few misc improvements:

* Improved type inference for shape tuples so that we correctly assign the type `UInt[64]` to literal elements of a literal shape.
* The numbered labels for specialized graphs are now more readable.
