### PR TITLE
Advanced optimization

### DIFF
--- a/myia/api.py
+++ b/myia/api.py
@@ -824,6 +824,31 @@ step_prepare = Preparator.partial(
 )
 
 
+step_debug_opt = Optimizer.partial(
+    phases=dict(
+        main=[
+            # Branch culling
+            optlib.simplify_always_true,
+            optlib.simplify_always_false,
+
+            # Safe inlining
+            optlib.inline_core,
+            optlib.simplify_partial,
+
+            # Miscellaneous
+            optlib.elim_j_jinv,
+            optlib.elim_jinv_j,
+        ],
+        grad=[
+            optlib.expand_J,
+        ],
+        renormalize='renormalize',
+        cse=CSE.partial(report_changes=False),
+        jelim=optlib.JElim.partial(),
+    )
+)
+
+
 step_opt = Optimizer.partial(
     phases=dict(
         main=[
@@ -832,6 +857,8 @@ step_opt = Optimizer.partial(
             optlib.simplify_always_false,
             optlib.simplify_switch1,
             optlib.simplify_switch2,
+            optlib.simplify_switch_idem,
+            optlib.combine_switches,
 
             # Safe inlining
             optlib.inline_trivial,
@@ -839,6 +866,9 @@ step_opt = Optimizer.partial(
             optlib.inline_core,
             optlib.simplify_partial,
             optlib.replace_applicator,
+
+            # Specialization
+            optlib.specialize_on_graph_arguments,
 
             # Arithmetic simplifications
             optlib.multiply_by_one_l,
@@ -861,12 +891,20 @@ step_opt = Optimizer.partial(
             optlib.elim_jinv_j,
             optlib.cancel_env_set_get,
             optlib.getitem_newenv,
+            optlib.getitem_env_add,
+            optlib.incorporate_getitem,
+            optlib.incorporate_env_getitem,
+            optlib.incorporate_call,
+            optlib.incorporate_getitem_through_switch,
+            optlib.incorporate_env_getitem_through_switch,
+            optlib.incorporate_call_through_switch,
         ],
         grad=[
             optlib.expand_J,
         ],
+        renormalize='renormalize',
         cse=CSE.partial(report_changes=False),
-        renormalize='renormalize'
+        jelim=optlib.JElim.partial(),
     )
 )
 
@@ -914,7 +952,12 @@ standard_resources = dict(
 )
 
 
-_standard_pipeline = PipelineDefinition(
+######################
+# Pre-made pipelines #
+######################
+
+
+standard_pipeline = PipelineDefinition(
     resources=standard_resources,
     steps=dict(
         parse=step_parse,
@@ -925,29 +968,30 @@ _standard_pipeline = PipelineDefinition(
         opt=step_opt,
         cconv=step_cconv,
         validate=step_validate,
-    )
-)
-
-
-######################
-# Pre-made pipelines #
-######################
-
-
-standard_pipeline = _standard_pipeline \
-    .insert_after(
         wrap_primitives=step_wrap_primitives,
         compile=step_compile,
         link=step_link,
         export=step_export,
         wrap=step_wrap,
     )
+)
 
-standard_debug_pipeline = _standard_pipeline \
-    .insert_after(
+
+standard_debug_pipeline = PipelineDefinition(
+    resources=standard_resources,
+    steps=dict(
+        parse=step_parse,
+        resolve=step_resolve,
+        infer=step_infer,
+        specialize=step_specialize,
+        prepare=step_prepare,
+        opt=step_debug_opt,
+        cconv=step_cconv,
+        validate=step_validate,
         export=step_debug_export,
         wrap=step_wrap,
     )
+)
 
 
 scalar_pipeline = standard_pipeline.configure({

--- a/myia/api.py
+++ b/myia/api.py
@@ -831,6 +831,8 @@ step_opt = Optimizer.partial(
             # Branch culling
             optlib.simplify_always_true,
             optlib.simplify_always_false,
+            optlib.simplify_switch1,
+            optlib.simplify_switch2,
 
             # Safe inlining
             optlib.inline_trivial,

--- a/myia/api.py
+++ b/myia/api.py
@@ -892,6 +892,11 @@ step_opt = Optimizer.partial(
             optlib.cancel_env_set_get,
             optlib.getitem_newenv,
             optlib.getitem_env_add,
+        ],
+        main2=[
+            # Costlier optimizations
+            optlib.float_tuple_getitem_through_switch,
+            optlib.float_env_getitem_through_switch,
             optlib.incorporate_getitem,
             optlib.incorporate_env_getitem,
             optlib.incorporate_call,

--- a/myia/api.py
+++ b/myia/api.py
@@ -259,7 +259,6 @@ standard_method_map = TypeMap({
 def default_convert(env, fn: FunctionType):
     """Default converter for Python types."""
     g = clone(parser.parse(fn))
-    env.resources.manager.add_graph(g)
     env.object_map[fn] = g
     return g
 
@@ -270,7 +269,6 @@ def default_convert(env, g: Graph):
     if g._manager is not mng:
         g2 = clone(g)
         env.object_map[g] = g2
-        mng.add_graph(g2)
         return g2
     else:
         return g
@@ -339,11 +337,12 @@ class Converter(PipelineResource):
             if isinstance(v, _Unconverted):
                 v = self.converter(self, v.value)
                 self.object_map[value] = v
-            return v
         except (TypeError, KeyError):
-            pass
+            v = self.converter(self, value)
 
-        return self.converter(self, value)
+        if isinstance(v, Graph):
+            self.resources.manager.add_graph(v)
+        return v
 
 
 class InferenceResource(PipelineResource):

--- a/myia/ir/__init__.py
+++ b/myia/ir/__init__.py
@@ -2,7 +2,7 @@
 
 from .abstract import Node  # noqa
 from .anf import Graph, ANFNode, Apply, Constant, Parameter, Special  # noqa
-from .clone import clone, GraphCloner  # noqa
+from .clone import clone, GraphCloner, transformable_clone  # noqa
 from .manager import (  # noqa
     ManagerError, manage, ParentProxy, GraphManager
 )

--- a/myia/ir/clone.py
+++ b/myia/ir/clone.py
@@ -190,3 +190,21 @@ def clone(g,
                        relation=relation,
                        clone_constants=clone_constants,
                        graph_relation=graph_relation)[g]
+
+
+def transformable_clone(graph, relation='transform'):
+    """Return a clone of the graph that can be safely transformed.
+
+    If the graph is recursive, recursive calls will point to the original
+    graph and not to the clone. This allows us to modify the returned graph
+    safely, without messing up the recursive call sites.
+    """
+    with About(graph.debug, relation):
+        newg = Graph()
+    for p in graph.parameters:
+        with About(p.debug, 'copy'):
+            newg.add_parameter()
+    cl = GraphCloner()
+    cl.add_clone(graph, newg, newg.parameters)
+    newg.output = cl[graph.output]
+    return newg

--- a/myia/opt/__init__.py
+++ b/myia/opt/__init__.py
@@ -4,7 +4,8 @@ from .opt import (  # noqa
     VarNode, sexp_to_node, sexp_to_graph,
     PatternSubstitutionOptimization,
     pattern_replacer,
-    PatternEquilibriumOptimizer
+    PatternEquilibriumOptimizer,
+    GraphTransform,
 )
 
 from .cse import (  # noqa

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -23,6 +23,8 @@ X1 = Var('X1')
 Y1 = Var('Y1')
 X2 = Var('X2')
 Y2 = Var('Y2')
+X3 = Var('X3')
+X4 = Var('X4')
 
 
 def _is_c(n):
@@ -229,6 +231,23 @@ simplify_always_false = psub(
     replacement=Y,
     name='simplify_always_false'
 )
+
+
+# Simplify nested switch with the same condition (case 1)
+simplify_switch1 = psub(
+    pattern=(P.switch, X1, (P.switch, X1, X2, X3), X4),
+    replacement=(P.switch, X1, X2, X4),
+    name='simplify_switch1'
+)
+
+
+# Simplify nested switch with the same condition (case 2)
+simplify_switch2 = psub(
+    pattern=(P.switch, X1, X2, (P.switch, X1, X3, X4)),
+    replacement=(P.switch, X1, X2, X4),
+    name='simplify_switch2'
+)
+
 
 #####################
 # Simplify partials #

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -1,5 +1,6 @@
 """Library of optimizations."""
 
+from ..composite import hyper_add
 from ..ir import Graph, Constant, GraphCloner, transformable_clone
 from ..prim import Primitive, ops as P
 from ..utils import Namespace
@@ -212,6 +213,17 @@ getitem_newenv = psub(
     replacement=Y,
     condition=lambda equiv: len(equiv[C1].value) == 0,
     name='getitem_newenv'
+)
+
+
+# getitem(env_add(e1, e2), key, default)
+#     => hyper_add(getitem(e1, key, default), getitem(e2, key, default))
+getitem_env_add = psub(
+    pattern=(P.env_getitem, (P.env_add, X, Y), C, Z),
+    replacement=(hyper_add,
+                 (P.env_getitem, X, C, Z),
+                 (P.env_getitem, Y, C, Z)),
+    name='getitem_env_add'
 )
 
 

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -25,6 +25,7 @@ X2 = Var('X2')
 Y2 = Var('Y2')
 X3 = Var('X3')
 X4 = Var('X4')
+X5 = Var('X5')
 
 
 def _is_c(n):
@@ -259,6 +260,34 @@ simplify_switch2 = psub(
     pattern=(P.switch, X1, X2, (P.switch, X1, X3, X4)),
     replacement=(P.switch, X1, X2, X4),
     name='simplify_switch2'
+)
+
+
+# Simplify switch when both branches are the same node
+simplify_switch_idem = psub(
+    pattern=(P.switch, X, Y, Y),
+    replacement=Y,
+    name='simplify_switch_idem'
+)
+
+
+_PutInSwitch = primset_var(
+    P.scalar_add,
+    P.scalar_sub,
+    P.scalar_mul,
+    P.scalar_div,
+    P.scalar_mod,
+    P.scalar_pow,
+)
+
+
+# Binary operations on switches with same conditions are transformed into
+# a switch on two operations, e.g.
+# switch(x, a, b) + switch(x, c, d) => switch(x, a + c, b + d)
+combine_switches = psub(
+    pattern=(_PutInSwitch, (P.switch, X1, X2, X3), (P.switch, X1, X4, X5)),
+    replacement=(P.switch, X1, (_PutInSwitch, X2, X4), (_PutInSwitch, X3, X5)),
+    name='combine_switches'
 )
 
 

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -293,6 +293,24 @@ combine_switches = psub(
 )
 
 
+float_tuple_getitem_through_switch = psub(
+    pattern=(P.tuple_getitem, (P.switch, X1, X2, X3), C),
+    replacement=(P.switch, X1,
+                 (P.tuple_getitem, X2, C),
+                 (P.tuple_getitem, X3, C)),
+    name='float_tuple_getitem_through_switch'
+)
+
+
+float_env_getitem_through_switch = psub(
+    pattern=(P.env_getitem, (P.switch, X1, X2, X3), X4, X5),
+    replacement=(P.switch, X1,
+                 (P.env_getitem, X2, X4, X5),
+                 (P.env_getitem, X3, X4, X5)),
+    name='float_env_getitem_through_switch'
+)
+
+
 #####################
 # Simplify partials #
 #####################

--- a/myia/prim/grad_implementations.py
+++ b/myia/prim/grad_implementations.py
@@ -103,6 +103,7 @@ def register_augm(prim):
             name = short_labeler.name(g2)
             name = name.replace('__fprop__', syms['grad_fprop'])
             g2.debug.name = name.replace('__bprop__', syms['grad_bprop'])
+            g2.flags.update(_flags)
         g.transforms['primal'] = prim
         return register(prim)(g)
     return deco

--- a/myia/prim/type_inferrers.py
+++ b/myia/prim/type_inferrers.py
@@ -213,6 +213,13 @@ async def infer_type_tuple_getitem(track, seq, idx):
             'Tuples must be indexed with a constant',
             refs=[seq, idx]
         )
+    nelems = len(seq_t.elements)
+    if not -nelems <= idx_v < nelems:
+        raise MyiaTypeError(
+            'Tuple element out of range',
+            refs=[seq, idx]
+        )
+
     return seq_t.elements[idx_v]
 
 

--- a/tests/opt/test_lib.py
+++ b/tests/opt/test_lib.py
@@ -329,6 +329,33 @@ def test_false_branch_switch():
                lib.simplify_always_false)
 
 
+def test_nested_switch_same_cond():
+
+    def before(a, b, c, d):
+        x = a < 0
+        return switch(x, switch(x, a, b), switch(x, c, d))
+
+    def after(a, b, c, d):
+        x = a < 0
+        return switch(x, a, d)
+
+    _check_opt(before, after,
+               lib.simplify_switch1,
+               lib.simplify_switch2)
+
+
+def test_nested_switch_diff_cond():
+
+    def before(a, b, c, d):
+        x = a < 0
+        y = b < 0
+        return switch(x, switch(y, a, b), switch(y, c, d))
+
+    _check_opt(before, before,
+               lib.simplify_switch1,
+               lib.simplify_switch2)
+
+
 ############
 # Partials #
 ############

--- a/tests/opt/test_lib.py
+++ b/tests/opt/test_lib.py
@@ -380,6 +380,34 @@ def test_nested_switch_diff_cond():
                lib.simplify_switch2)
 
 
+def test_switch_same_branch():
+
+    def before(x, y):
+        a = y * y
+        return switch(x < 0, a, a)
+
+    def after(x, y):
+        return y * y
+
+    _check_opt(before, after,
+               lib.simplify_switch_idem)
+
+
+def test_combine_switch():
+
+    def before(x, y):
+        cond = x < 0
+        a = switch(cond, x, y)
+        b = switch(cond, y, x)
+        return a + b
+
+    def after(x, y):
+        return switch(x < 0, x + y, y + x)
+
+    _check_opt(before, after,
+               lib.combine_switches)
+
+
 ############
 # Partials #
 ############

--- a/tests/opt/test_lib.py
+++ b/tests/opt/test_lib.py
@@ -408,6 +408,33 @@ def test_combine_switch():
                lib.combine_switches)
 
 
+def test_float_tuple_getitem_through_switch():
+
+    def before(x, y):
+        return switch(x < 0, x, y)[0]
+
+    def after(x, y):
+        return switch(x < 0, x[0], y[0])
+
+    _check_opt(before, after,
+               lib.float_tuple_getitem_through_switch)
+
+
+def test_float_env_getitem_through_switch():
+
+    def before(x, y):
+        return env_getitem(switch(x < 0, newenv, newenv), embed(y), 5)
+
+    def after(x, y):
+        key = embed(y)
+        return switch(x < 0,
+                      env_getitem(newenv, key, 5),
+                      env_getitem(newenv, key, 5))
+
+    _check_opt(before, after,
+               lib.float_env_getitem_through_switch)
+
+
 ############
 # Partials #
 ############

--- a/tests/opt/test_lib.py
+++ b/tests/opt/test_lib.py
@@ -4,7 +4,7 @@ from myia import dtype
 from myia.opt import lib
 from myia.prim.py_implementations import \
     scalar_add, scalar_mul, tail, tuple_setitem, identity, partial, switch, \
-    distribute, array_reduce, env_getitem, env_setitem, embed
+    distribute, array_reduce, env_getitem, env_setitem, embed, scalar_usub
 from myia.utils import newenv
 
 
@@ -680,6 +680,32 @@ def test_replace_applicator_2():
 
     _check_opt(before, before,
                lib.replace_applicator)
+
+
+##################
+# Specialization #
+##################
+
+
+def test_specialize_on_graph_arguments():
+
+    def square(x):
+        return x * x
+
+    def before(x, y):
+        def helper(f, x, g, y):
+            return f(x) + g(y)
+
+        return helper(square, x, scalar_usub, y)
+
+    def after(x, y):
+        def helper(x, y):
+            return square(x) + scalar_usub(y)
+
+        return helper(x, y)
+
+    _check_opt(before, after,
+               lib.specialize_on_graph_arguments)
 
 
 #################

--- a/tests/opt/test_lib.py
+++ b/tests/opt/test_lib.py
@@ -801,7 +801,23 @@ def test_incorporate_getitem():
 
     def after(x, y):
         def a_help(x, y):
-            return (x * y, x + y)[0]
+            return x * y
+        return a_help(x, y)
+
+    _check_opt(before, after,
+               lib.incorporate_getitem)
+
+
+def test_incorporate_getitem_2():
+
+    def before(x, y):
+        def b_help(x, y):
+            return x
+        return b_help(x, y)[0]
+
+    def after(x, y):
+        def a_help(x, y):
+            return x[0]
         return a_help(x, y)
 
     _check_opt(before, after,
@@ -821,10 +837,10 @@ def test_incorporate_getitem_through_switch():
 
     def after(x, y):
         def f1(x, y):
-            return (x, y)[0]
+            return x
 
         def f2(x, y):
-            return (y, x)[0]
+            return y
 
         return switch(x < 0, f1, f2)(x, y)
 
@@ -851,6 +867,23 @@ def test_incorporate_env_getitem():
                lib.cancel_env_set_get,
                argspec=[{'type': dtype.Float[64]},
                         {'type': dtype.Float[64]}])
+
+
+def test_incorporate_env_getitem_2():
+
+    def before(x, y):
+        def b_help(x, y):
+            return x
+        return env_getitem(b_help(x, y), 1234, 0)
+
+    def after(x, y):
+        def a_help(x, y):
+            return env_getitem(x, 1234, 0)
+        return a_help(x, y)
+
+    _check_opt(before, after,
+               lib.incorporate_env_getitem,
+               lib.cancel_env_set_get)
 
 
 def test_incorporate_env_getitem_through_switch():

--- a/tests/opt/test_opt.py
+++ b/tests/opt/test_opt.py
@@ -92,21 +92,28 @@ add_zero_r = psub(
 )
 
 
-def _check_transform(before, after, transform, argspec=None):
+def _check_transform(before, after, transform,
+                     argspec=None,
+                     argspec_after=None):
     if argspec is None:
         gbefore = parse(before)
         gafter = parse(after)
     else:
+        if argspec_after is None:
+            argspec_after = argspec
         gbefore = specialize.run(input=before, argspec=argspec)['graph']
-        gafter = specialize.run(input=after, argspec=argspec)['graph']
+        if argspec_after:
+            gafter = specialize.run(input=after, argspec=argspec)['graph']
+        else:
+            gafter = parse(after)
     gbefore = GraphCloner(gbefore, total=True)[gbefore]
     transform(gbefore)
     assert isomorphic(gbefore, gafter)
 
 
-def _check_opt(before, after, *opts, argspec=None):
+def _check_opt(before, after, *opts, argspec=None, argspec_after=None):
     eq = PatternEquilibriumOptimizer(*opts)
-    _check_transform(before, after, eq, argspec)
+    _check_transform(before, after, eq, argspec, argspec_after)
 
 
 def test_checkopt_is_cloning():

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -4,12 +4,11 @@ import numpy as np
 from types import FunctionType
 
 from myia import api
-from myia.api import standard_resources, Optimizer, Validator
+from myia.api import standard_resources, Validator
 from myia.composite import grad
 from myia.debug.finite_diff import GradTester, NoTestGrad, clean_args
 from myia.dtype import JTagged
 from myia.grad import J as realJ
-from myia.opt import lib as optlib, CSE
 from myia.pipeline import pipeline_function, PipelineDefinition
 from myia.prim import ops as P, Primitive
 from myia.prim.py_implementations import J, scalar_add, scalar_mul, \
@@ -27,29 +26,6 @@ grad_whitelist = whitelist | {P.J, P.Jinv}
 @validate_type.variant
 def grad_validate_type(self, t: JTagged):
     pass
-
-
-step_grad_opt = Optimizer.partial(
-    phases=dict(
-        main=[
-            optlib.simplify_always_true,
-            optlib.simplify_always_false,
-            optlib.inline_core,
-            optlib.simplify_partial,
-            optlib.elim_identity,
-        ],
-        grad=[
-            optlib.expand_J,
-        ],
-        renormalize='renormalize',
-        elimj=[
-            optlib.elim_j_jinv,
-            optlib.elim_jinv_j,
-        ],
-        cse=CSE.partial(report_changes=False),
-        jelim=optlib.JElim.partial(),
-    )
-)
 
 
 step_grad_validate = Validator.partial(
@@ -79,7 +55,7 @@ grad_pipeline = PipelineDefinition(
         resolve=api.step_resolve,
         infer=api.step_infer,
         specialize=api.step_specialize,
-        opt=step_grad_opt,
+        opt=api.step_debug_opt,
         validate=step_grad_validate,
         export=api.step_debug_export,
     )

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -47,6 +47,7 @@ step_grad_opt = Optimizer.partial(
             optlib.elim_jinv_j,
         ],
         cse=CSE.partial(report_changes=False),
+        jelim=optlib.JElim.partial(),
     )
 )
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -538,6 +538,21 @@ def test_tuple_getitem(x, y):
     return (x, y)[0]
 
 
+@infer(type=[(i64, f64, f64), (f64, i64, i64)])
+def test_tuple_getitem_negative(x, y):
+    return (x, y)[-1]
+
+
+@infer(type=[(i64, f64, InferenceError)])
+def test_tuple_outofbound(x, y):
+    return (x, y)[2]
+
+
+@infer(type=[(i64, f64, InferenceError)])
+def test_tuple_outofbound_negative(x, y):
+    return (x, y)[-3]
+
+
 @infer(
     type=[
         (li64, i64, i64),


### PR DESCRIPTION
This adds several advanced optimizations that are critical in optimizing the graphs created by gradients.

* "Incorporator" optimizations take a graph of the form `f((lambda x: y)(a), b)` and maps it to `(lambda x: f(y, b))(a)`. For example, if you have `(lambda x: (a, b))(c)[0]`, we transform that into `(lambda x: (a, b)[0])(c)`, which opens up an opportunity to optimize the getitem further and eliminate `b`.
  * Such optimizations are triggered for `tuple_getitem` (as above), `env_getitem` and calls (basically `f(x)(y)` => `f'(x, y)`)
* Many more optimizations apply on `switch`:
  * `switch(cond, x, x) => x`
  * `switch(cond, switch(cond, a, b), c) => switch(cond, a, c)`
  * `switch(cond, x, y)[0] => switch(cond, x[0], y[0])`
  * Incorporators apply through switch. For example, `switch(cond, f, g)(x)[0]` becomes `switch(cond, f0, g0)(x)`, where `f0(x)` is equivalent to `f(x)[0]`.
* The following simplification is applied to eliminate `env_add`:
  * `env_getitem(env_add(e1, e2), key, dflt) => hyper_add(env_getitem(e1, key, dflt), env_getitem(e2, key, dflt))`
* A global optimizer eliminates `J` and `Jinv` if no application of these primitives remains on functions.

Taken together, these optimizations appear to work: when applied to the test cases in `test_grad`, they successfully eradicate all occurrences of the `Env` and `JTagged` types. There are most probably situations not covered by these optimizations, but this is a promising start.

The one issue is that the optimizer simply doesn't scale anymore. I was not able to optimize `test_pow10` because it was still running after five minutes, and I'm not sure it's because there's an infinite loop. The fact is that the time to run it balloons as optimizations are added. From `debug_opt` to `opt`, running `test_while_2` goes from 1.5 to 8.5 seconds, for example.

I don't think that the optimization strategy is intrinsically costly. I think it's actually pretty good. However, the naive equilibrium optimizer is terrible.
