### PR TITLE
Improvements to specializer

### DIFF
--- a/myia/infer/__init__.py
+++ b/myia/infer/__init__.py
@@ -42,6 +42,5 @@ from .utils import (  # noqa
     VOID,
     DEAD,
     POLY,
-    AMBIGUOUS,
     INACCESSIBLE,
 )

--- a/myia/infer/graph_infer.py
+++ b/myia/infer/graph_infer.py
@@ -93,7 +93,7 @@ class Track(Partializable):
         """Convert a property provided outside the inferrer."""
         return v
 
-    def broaden(self, v):
+    def broaden(self, v, maximal=False):
         """Broaden the value for use in a graph's signature."""
         return v
 
@@ -268,7 +268,27 @@ class Inferrer(DynamicMap):
             (argrefs, res), *_ = self.cache.items()
             return argrefs
         else:
-            raise Unspecializable(POLY)
+            # We try to find argrefs that subsume all the existing argrefs
+            broadened = set()
+            for argrefs in self.cache:
+                vrefs = []
+                for arg in argrefs:
+                    vref = self.engine.vref({
+                        track_name: track.broaden(
+                            await arg[track_name],
+                            maximal=True
+                        )
+                        for track_name, track in self.engine.tracks.items()
+                    })
+                    vrefs.append(vref)
+                broadened.add(tuple(vrefs))
+            if len(broadened) == 1:
+                vrefs, = broadened
+                # We run the inference so that it's available in the cache
+                await self(*vrefs)
+                return vrefs
+            else:
+                raise Unspecializable(POLY)
 
     async def as_function_type(self, argrefs=None):
         """Return a Function type corresponding to this Inferrer.
@@ -701,6 +721,13 @@ class VirtualReference(AbstractReference):
 
     async def __getitem__(self, track):
         return self.values[track]
+
+    def __hash__(self):
+        return hash(tuple(sorted(self.values.items())))
+
+    def __eq__(self, other):
+        return isinstance(other, VirtualReference) \
+            and self.values == other.values
 
 
 class TransformedReference(AbstractReference):

--- a/myia/infer/utils.py
+++ b/myia/infer/utils.py
@@ -21,7 +21,6 @@ VOID = Named('VOID')
 DEAD = Named('DEAD')
 POLY = Named('POLY')
 INACCESSIBLE = Named('INACCESSIBLE')
-AMBIGUOUS = Named('AMBIGUOUS')
 
 
 class Unspecializable(Exception):

--- a/myia/prim/value_inferrers.py
+++ b/myia/prim/value_inferrers.py
@@ -158,10 +158,10 @@ class ValueTrack(Track):
         """Convert a property provided outside the inferrer."""
         return self.from_value(v, None)
 
-    def broaden(self, v):
+    def broaden(self, v, maximal=False):
         """Broaden the value if we reach a certain depth in the stack."""
-        if v is ANYTHING:
-            return v
+        if v is ANYTHING or maximal:
+            return ANYTHING
         else:
             return limited(v.value, v.count - 1)
 

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -331,7 +331,10 @@ def test_nested_closure(x):
     def f():
         def g():
             return a + b
-        return g
+
+        def h():
+            return a * b
+        return g if x < 0 else h
     return f()()
 
 

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -342,9 +342,6 @@ def test_functions_in_tuples(x, y):
     return f(x, y) + g(x, y)
 
 
-@pytest.mark.xfail(
-    reason="A DummyInferrer is unfortunately propagated into a call."
-)
 @grad_test((4.5, 6.7),)
 def test_closures_in_tuples(x, y):
     def f():

--- a/tests/test_specialize.py
+++ b/tests/test_specialize.py
@@ -252,8 +252,6 @@ def test_poly_with_constants(c, x, y):
     return choose(c)(x, y), choose(not c)(x, y)
 
 
-@mark.xfail(reason="Distinct contexts are created for 2 and 3, "
-                   "leading to Problem(POLY).")
 @specialize((True, int1, int2))
 def test_poly_with_constants2(c, x, y):
     def f1(x, y):

--- a/tests/test_specialize.py
+++ b/tests/test_specialize.py
@@ -299,3 +299,34 @@ def test_switch2(c, x, y):
 @specialize((int1, int2, int2))
 def test_multitype(x, y, z):
     return mysum(x) * mysum(x, y) * mysum(x, y, z)
+
+
+@specialize((int1, int2))
+def test_closure_stays_in_scope(x, y):
+    # The inferrer knows that h(x + y) is the graph for g, but
+    # it shouldn't try to replace the expression with that graph,
+    # because it points to a fv in f.
+    def f(z):
+        def g():
+            return z
+        return g
+
+    def h(z):
+        a = z * z
+        return f(a)
+
+    return h(x + y)()
+
+
+@specialize((int1, int2))
+def test_partial_outside_scope(x, y):
+    # The inferrer knows that g(x) is a partial of f, but it can't
+    # build it inside the main function.
+    def f(x, y):
+        return x * y
+
+    def g(x):
+        z = x * x
+        return partial(f, z)
+
+    return g(x)(y)


### PR DESCRIPTION
* The specializer doesn't process nodes that it doesn't need to, leading to performance improvements.
* Some circumstances that would produce `Problem[POLY]` now generate correct specialized graphs: when multiple competing signatures are found, we attempt to find a generalized version of them (e.g. with all values set to ANYTHING), and then we run inference for the generalized version.
* A bug was fixed where an invalid graph may be generated for a partial that's returned by a function. `test_specialize::test_partial_outside_scope` covers this case.
