### PR TITLE
Speed up optimisations

### DIFF
--- a/myia/composite.py
+++ b/myia/composite.py
@@ -286,11 +286,11 @@ def int_truediv(x, y):
     if hastype(x, typeof(y)):
         if (hastype(x, i8) or hastype(x, ui8) or
                 hastype(x, i16) or hastype(x, ui16)):
-            return scalar_cast(x, f32) / scalar_cast(y, f32)
-        return scalar_cast(x, f64) / scalar_cast(y, f64)
+            return scalar_div(scalar_cast(x, f32), scalar_cast(y, f32))
+        return scalar_div(scalar_cast(x, f64), scalar_cast(y, f64))
     else:
         # This branch is only here to trigger a type check error.
-        return x / y
+        return scalar_div(x, y)
 
 
 @core

--- a/myia/opt/__init__.py
+++ b/myia/opt/__init__.py
@@ -4,6 +4,7 @@ from .opt import (  # noqa
     VarNode, sexp_to_node, sexp_to_graph,
     PatternSubstitutionOptimization,
     pattern_replacer,
+    GlobalPassOptimizer,
     PatternEquilibriumOptimizer,
     GraphTransform,
 )

--- a/myia/opt/__init__.py
+++ b/myia/opt/__init__.py
@@ -3,8 +3,8 @@
 from .opt import (  # noqa
     VarNode, sexp_to_node, sexp_to_graph,
     PatternSubstitutionOptimization,
-    pattern_replacer,
-    GlobalPassOptimizer,
+    NodeMap, pattern_replacer,
+    LocalPassOptimizer,
     PatternEquilibriumOptimizer,
     GraphTransform,
 )

--- a/myia/opt/__init__.py
+++ b/myia/opt/__init__.py
@@ -5,7 +5,6 @@ from .opt import (  # noqa
     PatternSubstitutionOptimization,
     NodeMap, pattern_replacer,
     LocalPassOptimizer,
-    PatternEquilibriumOptimizer,
     GraphTransform,
 )
 

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -311,7 +311,7 @@ def simplify_array_map(optimizer, node, equiv):
             args = [to_outer(arg) for arg in out.inputs[1:]]
             return node.graph.apply(P.array_map, out.inputs[0], *args)
         else:
-            return node
+            return node  # pragma: no cover
 
     except NotImplementedError:
         if g.flags.get('inline_inside'):

--- a/myia/opt/opt.py
+++ b/myia/opt/opt.py
@@ -8,6 +8,7 @@ from ..ir import ANFNode, Apply, Constant, Graph, Special, manage, \
 from ..prim import Primitive
 from ..graph_utils import dfs
 from ..utils.unify import Unification, Var
+from ..utils import prof_counter
 
 
 class VarNode(Special):

--- a/myia/opt/opt.py
+++ b/myia/opt/opt.py
@@ -3,10 +3,8 @@
 from weakref import WeakKeyDictionary
 from collections import deque
 
-from ..ir import ANFNode, Apply, Constant, Graph, Special, manage, \
-    succ_deeper
+from ..ir import ANFNode, Apply, Constant, Graph, Special, manage
 from ..prim import Primitive
-from ..graph_utils import dfs
 from ..utils.unify import Unification, Var
 
 

--- a/myia/opt/opt.py
+++ b/myia/opt/opt.py
@@ -155,13 +155,13 @@ class NodeMap:
     def register(self, interests, opt=None):
 
         def do_register(opt):
-            nonlocal interests
-            if interests is None:
+            ints = interests
+            if ints is None:
                 self._d.setdefault(None, []).append(opt)
                 return
-            if not isinstance(interests, tuple):
-                interests = (interests,)
-            for interest in interests:
+            if not isinstance(ints, tuple):
+                ints = (ints,)
+            for interest in ints:
                 assert isinstance(interest, Primitive)
                 self._d.setdefault(interest, []).append(opt)
 
@@ -173,7 +173,7 @@ class NodeMap:
     def get(self, node):
         res = []
         res.extend(self._d.get(None, []))
-        if node.is_apply(Primitive):
+        if node.is_apply() and node.inputs[0].is_constant():
             res.extend(self._d.get(node.inputs[0].value, []))
         return res
 

--- a/myia/opt/opt.py
+++ b/myia/opt/opt.py
@@ -8,7 +8,6 @@ from ..ir import ANFNode, Apply, Constant, Graph, Special, manage, \
 from ..prim import Primitive
 from ..graph_utils import dfs
 from ..utils.unify import Unification, Var
-from ..utils import prof_counter
 
 
 class VarNode(Special):
@@ -108,7 +107,7 @@ class PatternSubstitutionOptimization:
         self.name = name
         if interest is False:
             if (self.pattern.is_apply() and
-                self.pattern.inputs[0].is_constant(Primitive)):
+                    self.pattern.inputs[0].is_constant(Primitive)):
                 interest = self.pattern.inputs[0].value
             else:
                 # Maybe warn in this case?
@@ -186,7 +185,6 @@ class LocalPassOptimizer:
         self.node_map = node_map
         self.optimizer = optimizer
 
-
     def __call__(self, graph):
         """Apply optimizations on given graphs in node order."""
         if self.optimizer is not None:
@@ -197,7 +195,6 @@ class LocalPassOptimizer:
 
         changes = False
         again = True
-        count = 1
         while again:
             topo, seen, chg = self.backwards(mng, graph)
             again = self.forward(mng, topo)
@@ -266,7 +263,6 @@ class LocalPassOptimizer:
         return n, changes
 
 
-
 class PatternEquilibriumOptimizer:
     """Apply a set of local pattern optimizations until equilibrium."""
 
@@ -288,6 +284,7 @@ class PatternEquilibriumOptimizer:
         while True:
             changes = False
             nodes = list(dfs(graph.output, succ_deeper))
+
             def new_node(_, n):
                 nodes.append(n)
             mng.events.add_node.register(new_node)

--- a/myia/opt/opt.py
+++ b/myia/opt/opt.py
@@ -227,7 +227,7 @@ class LocalPassOptimizer:
         """
         seen = set([graph])
         todo = deque()
-        topo = list()
+        fwd = list()
         changes = False
         todo.appendleft(graph.output)
 
@@ -237,22 +237,18 @@ class LocalPassOptimizer:
                 continue
             seen.add(n)
 
-            if n.is_constant(Graph):
-                if n.value in seen:
-                    continue
-                todo.append(n.value.output)
-                continue
-
             new, chg = self.apply_opt(mng, n)
             changes |= chg
 
+            fwd.append(new)
             if new.is_constant(Graph):
-                todo.append(new)
+                if new.value not in seen:
+                    todo.append(new.value.output)
+                    seen.add(new.value)
             else:
-                topo.append(new)
                 todo.extendleft(new.inputs)
 
-        return topo, seen, changes
+        return fwd, seen, changes
 
     def forward(self, mng, topo):
         """Do a pass over the nodes.

--- a/myia/opt/opt.py
+++ b/myia/opt/opt.py
@@ -94,7 +94,8 @@ class PatternSubstitutionOptimization:
                  *,
                  condition=None,
                  name=None,
-                 multigraph=True):
+                 multigraph=True,
+                 interest=False):
         """Initialize va PatternSubstitutionOptimization."""
         g: Var = Var('RootG')
         self.pattern = sexp_to_node(pattern, g, multigraph)
@@ -105,6 +106,14 @@ class PatternSubstitutionOptimization:
         self.unif = Unification()
         self.condition = condition
         self.name = name
+        if interest is False:
+            if (self.pattern.is_apply() and
+                self.pattern.inputs[0].is_constant(Primitive)):
+                interest = self.pattern.inputs[0].value
+            else:
+                # Maybe warn in this case?
+                interest = None
+        self.interest = interest
 
     def __call__(self, optimizer, node):
         """Return a replacement for the node, if the pattern matches.

--- a/myia/opt/opt.py
+++ b/myia/opt/opt.py
@@ -201,7 +201,7 @@ class LocalPassOptimizer:
             mng = self.optimizer.resources.manager
             mng.add_graph(graph)
         else:
-            mng = manage(graph)  # noqa
+            mng = manage(graph)
 
         changes = False
         again = True
@@ -209,7 +209,6 @@ class LocalPassOptimizer:
             topo, seen, chg = self.backwards(mng, graph)
             again = self.forward(mng, topo)
             changes |= (chg | again)
-            again |= mng.all_nodes.issuperset(seen)
 
         return changes
 

--- a/myia/pipeline/pipeline.py
+++ b/myia/pipeline/pipeline.py
@@ -1,8 +1,7 @@
 """Tools to generate and configure Myia's operation pipeline."""
 
-from time import perf_counter
 from ..utils import merge, Merge, NS, Partial, Partializable, \
-    partition_keywords
+    partition_keywords, prof_counter
 
 
 class PipelineDefinition:
@@ -244,7 +243,7 @@ class _PipelineSlice:
         profile = args.get('profile', True)
         if profile:
             profd = dict()
-            gstart = perf_counter()
+            gstart = prof_counter()
         for step in self.pipeline._seq[self.slice]:
             if 'error' in args:
                 break
@@ -252,10 +251,10 @@ class _PipelineSlice:
                 valid_args, rest = partition_keywords(step.step, args)
                 try:
                     if profile:
-                        start = perf_counter()
+                        start = prof_counter()
                     results = step.step(**valid_args)
                     if profile:
-                        end = perf_counter()
+                        end = prof_counter()
                     if not isinstance(results, dict) and len(valid_args) == 1:
                         field_name, = valid_args.keys()
                         results = {field_name: results}
@@ -269,7 +268,7 @@ class _PipelineSlice:
                     args['error'] = e
                     args['error_step'] = step
         if profile:
-            gend = perf_counter()
+            gend = prof_counter()
             profd['__total__'] = gend - gstart
             args['profile'] = profd
         return args

--- a/myia/pipeline/pipeline.py
+++ b/myia/pipeline/pipeline.py
@@ -1,6 +1,6 @@
 """Tools to generate and configure Myia's operation pipeline."""
 
-
+from time import perf_counter
 from ..utils import merge, Merge, NS, Partial, Partializable, \
     partition_keywords
 
@@ -241,13 +241,25 @@ class _PipelineSlice:
         Errors are put in the 'error' key of the result, and the step
         at which an error happened is put in the 'error_step' key.
         """
+        profile = args.get('profile', True)
+        if profile:
+            profd = dict()
+            gstart = perf_counter()
         for step in self.pipeline._seq[self.slice]:
             if 'error' in args:
                 break
             if step.active:
                 valid_args, rest = partition_keywords(step.step, args)
                 try:
+                    if profile:
+                        start = perf_counter()
                     results = step.step(**valid_args)
+                    if profile:
+                        end = perf_counter()
+                        subp = results.pop('profile', end - start)
+                        if isinstance(subp, dict):
+                            subp['__total__'] = end - start
+                        profd[step.name] = subp
                     if not isinstance(results, dict) and len(valid_args) == 1:
                         field_name, = valid_args.keys()
                         results = {field_name: results}
@@ -255,6 +267,10 @@ class _PipelineSlice:
                 except Exception as e:
                     args['error'] = e
                     args['error_step'] = step
+        if profile:
+            gend = perf_counter()
+            profd['__total__'] = gend - gstart
+            args['profile'] = profd
         return args
 
     def __call__(self, **args):

--- a/myia/pipeline/pipeline.py
+++ b/myia/pipeline/pipeline.py
@@ -256,13 +256,14 @@ class _PipelineSlice:
                     results = step.step(**valid_args)
                     if profile:
                         end = perf_counter()
+                    if not isinstance(results, dict) and len(valid_args) == 1:
+                        field_name, = valid_args.keys()
+                        results = {field_name: results}
+                    if profile:
                         subp = results.pop('profile', end - start)
                         if isinstance(subp, dict):
                             subp['__total__'] = end - start
                         profd[step.name] = subp
-                    if not isinstance(results, dict) and len(valid_args) == 1:
-                        field_name, = valid_args.keys()
-                        results = {field_name: results}
                     args = {**args, **results}
                 except Exception as e:
                     args['error'] = e

--- a/myia/pipeline/pipeline.py
+++ b/myia/pipeline/pipeline.py
@@ -240,7 +240,7 @@ class _PipelineSlice:
         Errors are put in the 'error' key of the result, and the step
         at which an error happened is put in the 'error_step' key.
         """
-        profile = args.get('profile', True)
+        profile = args.get('profile', False)
         if profile:
             profd = dict()
             gstart = prof_counter()

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -10,8 +10,8 @@ from itertools import count
 from .. import dtype
 from ..cconv import closure_convert
 from ..ir import Graph
-from ..opt import PatternEquilibriumOptimizer, lib as optlib, CSE, \
-    erase_class, erase_tuple, NodeMap, LocalPassOptimizer
+from ..opt import lib as optlib, CSE, erase_class, erase_tuple, NodeMap, \
+    LocalPassOptimizer
 from ..prim import vm_implementations
 from ..utils import overload, flatten, prof_counter
 from ..validate import validate, whitelist as default_whitelist, \

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -331,8 +331,16 @@ step_opt2 = Optimizer.partial(
             optlib.unfuse_composite,
         ],
         main2=[
-            optlib.incorporate_getitem,
             optlib.getitem_tuple,
+            optlib.setitem_tuple,
+            optlib.setitem_tuple_ct,
+            optlib.float_tuple_getitem_through_switch,
+            optlib.incorporate_getitem,
+            optlib.incorporate_getitem_through_switch,
+            optlib.inline_trivial,
+            optlib.inline_unique_uses,
+            optlib.inline_inside_marked_caller,
+            optlib.inline_core,
         ],
     )
 )

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -54,7 +54,7 @@ class Optimizer(PipelineStep):
             elif isinstance(spec, list):
                 nmap = NodeMap()
                 for opt in spec:
-                    nmap.register(None, opt)
+                    nmap.register(getattr(opt, 'interest', None), opt)
                 spec = LocalPassOptimizer(nmap, optimizer=self)
             else:
                 spec = spec(optimizer=self)

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -12,7 +12,7 @@ from .. import dtype
 from ..cconv import closure_convert
 from ..ir import Graph
 from ..opt import PatternEquilibriumOptimizer, lib as optlib, CSE, \
-    erase_class, erase_tuple, NodeMap
+    erase_class, erase_tuple, NodeMap, LocalPassOptimizer
 from ..prim import vm_implementations
 from ..utils import overload, flatten
 from ..validate import validate, whitelist as default_whitelist, \
@@ -56,7 +56,8 @@ class Optimizer(PipelineStep):
                 nmap = NodeMap()
                 for opt in spec:
                     nmap.register(None, opt)
-                spec = PatternEquilibriumOptimizer(nmap, optimizer=self)
+                #spec = PatternEquilibriumOptimizer(nmap, optimizer=self)
+                spec = LocalPassOptimizer(nmap, optimizer=self)
             else:
                 spec = spec(optimizer=self)
             self.names.append(name)

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -12,7 +12,7 @@ from .. import dtype
 from ..cconv import closure_convert
 from ..ir import Graph
 from ..opt import PatternEquilibriumOptimizer, lib as optlib, CSE, \
-    erase_class, erase_tuple
+    erase_class, erase_tuple, NodeMap
 from ..prim import vm_implementations
 from ..utils import overload, flatten
 from ..validate import validate, whitelist as default_whitelist, \
@@ -53,7 +53,10 @@ class Optimizer(PipelineStep):
             if spec == 'renormalize':
                 pass
             elif isinstance(spec, list):
-                spec = PatternEquilibriumOptimizer(*spec, optimizer=self)
+                nmap = NodeMap()
+                for opt in spec:
+                    nmap.register(None, opt)
+                spec = PatternEquilibriumOptimizer(nmap, optimizer=self)
             else:
                 spec = spec(optimizer=self)
             self.names.append(name)

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -5,7 +5,6 @@ The steps are listed in roughly the same order they should be called.
 
 
 import numpy as np
-from time import perf_counter
 from itertools import count
 
 from .. import dtype
@@ -14,7 +13,7 @@ from ..ir import Graph
 from ..opt import PatternEquilibriumOptimizer, lib as optlib, CSE, \
     erase_class, erase_tuple, NodeMap, LocalPassOptimizer
 from ..prim import vm_implementations
-from ..utils import overload, flatten
+from ..utils import overload, flatten, prof_counter
 from ..validate import validate, whitelist as default_whitelist, \
     validate_type as default_validate_type
 from ..vm import VM
@@ -66,20 +65,19 @@ class Optimizer(PipelineStep):
         """Optimize the graph using the given patterns."""
         if profile:
             profd = dict()
-            gstart = perf_counter()
+            gstart = prof_counter()
             counter = count(1)
         changes = True
         while changes:
             if profile:
-                lstart = perf_counter()
+                lstart = prof_counter()
                 loop = str(next(counter))
                 lp = dict()
                 nn = iter(self.names)
             changes = False
             for opt in self.phases:
                 if profile:
-                    subp = dict()
-                    start = perf_counter()
+                    start = prof_counter()
                 if opt == 'renormalize':
                     assert argspec is not None
                     graph = self.resources.inferrer.renormalize(
@@ -88,23 +86,23 @@ class Optimizer(PipelineStep):
                 elif opt(graph):
                     changes = True
                 if profile:
-                    end = perf_counter()
+                    end = prof_counter()
                     lp[next(nn)] = end - start
             if profile:
-                lend = perf_counter()
+                lend = prof_counter()
                 lp['__total__'] = lend - lstart
                 profd[f"Cycle {loop}"] = lp
             if self.run_only_once:
                 break
         if profile:
-            start = perf_counter()
+            start = prof_counter()
         self.resources.manager.keep_roots(graph)
         if profile:
-            end = perf_counter()
+            end = prof_counter()
             profd['keep_roots'] = end - start
         res = {'graph': graph}
         if profile:
-            gend = perf_counter()
+            gend = prof_counter()
             profd['__count__'] = next(counter) - 1
             profd['__total__'] = gend - gstart
             res['profile'] = profd

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -56,7 +56,6 @@ class Optimizer(PipelineStep):
                 nmap = NodeMap()
                 for opt in spec:
                     nmap.register(None, opt)
-                #spec = PatternEquilibriumOptimizer(nmap, optimizer=self)
                 spec = LocalPassOptimizer(nmap, optimizer=self)
             else:
                 spec = spec(optimizer=self)

--- a/myia/utils/__init__.py
+++ b/myia/utils/__init__.py
@@ -16,6 +16,8 @@ from .partial import (  # noqa
     partition_keywords, Partial, Partializable
 )
 
+from .profile import prof_counter, print_profile  # noqa
+
 from .unify import (  # noqa
     Unification, Var, Seq, SVar, UnionVar, RestrictedVar, PredicateSet,
     FilterVar, var, svar, uvar, expandlist, noseq, VisitError

--- a/myia/utils/profile.py
+++ b/myia/utils/profile.py
@@ -18,9 +18,9 @@ def print_profile(prof, *, indent=0):
 
     print(f"{ind}Total time taken: {unit(total)}")
     if count is not None:
-        print(f"{ind}  Number of loops: {count}") 
-    print(f"{ind}  Overhead: {unit(overhead)}")
-    print(f"{ind}  Time spent in runtime: {unit(runtime)}")
+        print(f"{ind} Number of loops: {count}")
+    print(f"{ind} Overhead: {unit(overhead)}")
+    print(f"{ind} Time spent in runtime: {unit(runtime)}")
     for k, v in prof.items():
         if isinstance(v, dict):
             print(f"{ind}  {k}:")

--- a/myia/utils/profile.py
+++ b/myia/utils/profile.py
@@ -1,11 +1,14 @@
+"""Utilities to help support profiling."""
+
 from time import perf_counter as prof_counter  # noqa
 
 
-def unit(secs):
+def _unit(secs):
     return "%.3gs" % secs
 
 
 def print_profile(prof, *, indent=0):
+    """Print a visualisation of a profile."""
     total = prof.pop('__total__')
     count = prof.pop('__count__', None)
     runtime = 0
@@ -18,14 +21,14 @@ def print_profile(prof, *, indent=0):
 
     overhead = total - runtime
 
-    print(f"{ind}Total time taken: {unit(total)}")
+    print(f"{ind}Total time taken: {_unit(total)}")
     if count is not None:
         print(f"{ind} Number of loops: {count}")
-    print(f"{ind} Overhead: {unit(overhead)}")
-    print(f"{ind} Time spent in runtime: {unit(runtime)}")
+    print(f"{ind} Overhead: {_unit(overhead)}")
+    print(f"{ind} Time spent in runtime: {_unit(runtime)}")
     for k, v in prof.items():
         if isinstance(v, dict):
             print(f"{ind}  {k}:")
             print_profile(v, indent=indent + 4)
         else:
-            print(f"{ind}  {k}: {unit(v)}")
+            print(f"{ind}  {k}: {_unit(v)}")

--- a/myia/utils/profile.py
+++ b/myia/utils/profile.py
@@ -1,11 +1,11 @@
-from time import perf_counter as prof_counter
+from time import perf_counter as prof_counter  # noqa
+
 
 def unit(secs):
     return "%.3gs" % secs
 
 
 def print_profile(prof, *, indent=0):
-    steps = dict()
     total = prof.pop('__total__')
     count = prof.pop('__count__', None)
     runtime = 0

--- a/myia/utils/profile.py
+++ b/myia/utils/profile.py
@@ -1,3 +1,5 @@
+from time import perf_counter as prof_counter
+
 def unit(secs):
     return "%.3gs" % secs
 

--- a/myia/utils/profile.py
+++ b/myia/utils/profile.py
@@ -1,0 +1,29 @@
+def unit(secs):
+    return "%.3gs" % secs
+
+
+def print_profile(prof, *, indent=0):
+    steps = dict()
+    total = prof.pop('__total__')
+    count = prof.pop('__count__', None)
+    runtime = 0
+    ind = " " * indent
+
+    for v in prof.values():
+        if isinstance(v, dict):
+            v = v['__total__']
+        runtime += v
+
+    overhead = total - runtime
+
+    print(f"{ind}Total time taken: {unit(total)}")
+    if count is not None:
+        print(f"{ind}  Number of loops: {count}") 
+    print(f"{ind}  Overhead: {unit(overhead)}")
+    print(f"{ind}  Time spent in runtime: {unit(runtime)}")
+    for k, v in prof.items():
+        if isinstance(v, dict):
+            print(f"{ind}  {k}:")
+            print_profile(v, indent=indent + 4)
+        else:
+            print(f"{ind}  {k}: {unit(v)}")

--- a/myia/utils/profile.py
+++ b/myia/utils/profile.py
@@ -3,11 +3,11 @@
 from time import perf_counter as prof_counter  # noqa
 
 
-def _unit(secs):
+def _unit(secs):  # pragma: no cover
     return "%.3gs" % secs
 
 
-def print_profile(prof, *, indent=0):
+def print_profile(prof, *, indent=0):  # pragma: no cover
     """Print a visualisation of a profile."""
     total = prof.pop('__total__')
     count = prof.pop('__count__', None)

--- a/tests/compile/test_nnvm.py
+++ b/tests/compile/test_nnvm.py
@@ -127,7 +127,6 @@ def test_distribute2(x):
     return distribute(x, (2, 3))
 
 
-@pytest.mark.xfail(reason="Devolves to empty function")
 @parse_compare(MA(2, 3), array=True, optimize=False)
 def test_distribute3(x):
     return distribute(x, (2, 3))

--- a/tests/compile/test_nnvm.py
+++ b/tests/compile/test_nnvm.py
@@ -25,7 +25,7 @@ def test_mul(x, y):
     return x * y
 
 
-@pytest.mark.xfail(reason="truediv doesn't work for ints")
+@pytest.mark.xfail(reason="scalar_cast is needed for ints")
 @parse_compare((2, 3), (2.0, 3.0))
 def test_truediv(x, y):
     return x / y

--- a/tests/opt/test_opt.py
+++ b/tests/opt/test_opt.py
@@ -6,7 +6,7 @@ from myia.pipeline import scalar_pipeline
 from myia.infer import InferenceError
 from myia.ir import Constant, isomorphic, GraphCloner
 from myia.opt import PatternSubstitutionOptimization as psub, \
-    PatternEquilibriumOptimizer, pattern_replacer, sexp_to_graph, \
+    LocalPassOptimizer, pattern_replacer, sexp_to_graph, \
     cse, NodeMap
 from myia.prim import Primitive, ops as prim
 from myia.utils import Merge
@@ -115,7 +115,7 @@ def _check_opt(before, after, *opts, argspec=None, argspec_after=None):
     nmap = NodeMap()
     for opt in opts:
         nmap.register(getattr(opt, 'interest', None), opt)
-    eq = PatternEquilibriumOptimizer(nmap)
+    eq = LocalPassOptimizer(nmap)
     _check_transform(before, after, eq, argspec, argspec_after)
 
 

--- a/tests/opt/test_opt.py
+++ b/tests/opt/test_opt.py
@@ -7,7 +7,7 @@ from myia.infer import InferenceError
 from myia.ir import Constant, isomorphic, GraphCloner
 from myia.opt import PatternSubstitutionOptimization as psub, \
     PatternEquilibriumOptimizer, pattern_replacer, sexp_to_graph, \
-    cse
+    cse, NodeMap
 from myia.prim import Primitive, ops as prim
 from myia.utils import Merge
 from myia.utils.unify import Var, var
@@ -112,7 +112,10 @@ def _check_transform(before, after, transform,
 
 
 def _check_opt(before, after, *opts, argspec=None, argspec_after=None):
-    eq = PatternEquilibriumOptimizer(*opts)
+    nmap = NodeMap()
+    for opt in opts:
+        nmap.register(getattr(opt, 'interest', None), opt)
+    eq = PatternEquilibriumOptimizer(nmap)
     _check_transform(before, after, eq, argspec, argspec_after)
 
 

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -14,7 +14,8 @@ debug_fn = standard_debug_pipeline \
     .select('parse', 'resolve', 'infer', 'specialize', 'export')
 
 
-def parse_compare(*tests, optimize=True, array=False, python=True):
+def parse_compare(*tests, optimize=True, array=False, profile=False,
+                  python=True):
     """Decorate a function to parse and run it against pure Python.
 
     Returns a unit test that will parse the function, and then for
@@ -37,7 +38,7 @@ def parse_compare(*tests, optimize=True, array=False, python=True):
             if python:
                 ref_result = fn(*map(copy, args))
             argspec = tuple({'value': a} for a in args)
-            res = pipeline.run(input=fn, argspec=argspec)
+            res = pipeline.run(input=fn, argspec=argspec, profile=profile)
             myia_fn = res['output']
             myia_result = myia_fn(*map(copy, args))
             if python:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -117,6 +117,11 @@ def test_forward_specialize(model, x):
     return model.apply(x)
 
 
+@parse_compare((make_model(), MC(3, 6)), array=True, profile=True)
+def test_forward_profile(model, x):
+    return model.apply(x)
+
+
 @infer_std(
     type=[
         ({'value': make_model()},


### PR DESCRIPTION
This speeds up the optimisations by about 2X by
 - changing iteration order to avoid going into parts of the graph that will be removed.
 - Making sure we only attempt relevant optimizations for nodes.

This also adds limited support for profiling pipelines to get some insight into what is slow/fast.

We could go a bit further by re-visiting uses of a node when we apply a change on a visited node because that could make the optimizer require even less passes to get a full set done.