### PR TITLE
Don't optimize removed nodes

### DIFF
--- a/myia/opt/opt.py
+++ b/myia/opt/opt.py
@@ -230,7 +230,7 @@ class LocalPassOptimizer:
 
         while len(todo) > 0:
             n = todo.pop()
-            if n in seen:
+            if n in seen or n not in mng.all_nodes:
                 continue
             seen.add(n)
 


### PR DESCRIPTION
I don't really understand why some removed nodes end up in the todo list, but since I plan on reworking that soon-ish, I don't want to spend a lot of time figuring that out.

In the meantime, the problem is avoided by skipping those nodes.

Fixes #156