### PR TITLE
Fix debug closures problems

### DIFF
--- a/myia/vm.py
+++ b/myia/vm.py
@@ -115,7 +115,7 @@ class VM:
         rval = set()
         for fv in graph.free_variables_total:
             if isinstance(fv, Graph):
-                rval.update(ct for ct in graph.constants if ct.value is fv)
+                rval.update(graph.manager.graph_constants[fv])
             else:
                 rval.add(fv)
         return rval
@@ -274,6 +274,8 @@ class VM:
         if isinstance(node, Constant):
             # We only visit constant graphs
             assert node.is_constant_graph()
+            if frame.closure is not None and node in frame.closure:
+                return
             g = node.value
             if len(self._vars[g]) != 0:
                 frame.values[node] = self._make_closure(g, frame)

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -385,6 +385,18 @@ def test_closure3(x):
     return g()()
 
 
+@parse_compare(7)
+def test_closure4(x):
+    def f():
+        return x
+
+    def g(y):
+        def h():
+            return y * f()
+        return h()
+    return g(5)
+
+
 @parse_compare(2)
 def test_fn1(x):
     def g(x):


### PR DESCRIPTION
This might be inefficient if there are a lot of graph constants, but it should work.

Fixing the multiple redundant closures would require a rework to either:
 - collapse all graph constants to a single instance or
 - use the graph instead of the constant as a stand-in

Both of those options require rewriting a lot of code that manipulates nodes (especially the latter) and it would be tricky to ensure that all corner cases are handled, so I went with the safe solution.

Fixes #159 